### PR TITLE
Fix nativeLoader call

### DIFF
--- a/java/core/src/main/scala/com/azavea/gdal/GDALWarp.scala
+++ b/java/core/src/main/scala/com/azavea/gdal/GDALWarp.scala
@@ -18,7 +18,7 @@ class GDALWarp(val uri: String, val opts: Array[String]) extends Native {
   @native def close(): Unit
 }
 
-@nativeLoader("gdaljni0")
+@nativeLoader("gdaljni.0.0")
 object GDALWarp {
 
 }


### PR DESCRIPTION
Terminal output: 

```bash
$ ./sbt
[info] Loading settings for project global-plugins from idea.sbt ...
[info] Loading global plugins from /Users/daunnc/.sbt/1.0/plugins
[info] Loading settings for project java-build from plugins.sbt ...
[info] Loading project definition from /Users/daunnc/subversions/git/github/pomadchin/gdal-warp-bindings/java/project
[info] Loading settings for project root from build.sbt ...
[info] Set current project to gdal-jni (in build file:/Users/daunnc/subversions/git/github/pomadchin/gdal-warp-bindings/java/)
[info] sbt server started at local:///Users/daunnc/.sbt/1.0/server/3937c4bdeaa8566eaf3c/sock
root > project core
[info] Set current project to gdal (in build file:/Users/daunnc/subversions/git/github/pomadchin/gdal-warp-bindings/java/)
core > test
[info] Updating native...
[info] Done updating.
[info] Updating ...
[info] Done updating.
[info] Building library with native build tool CMake
[info] Compiling 3 Scala sources to /Users/daunnc/subversions/git/github/pomadchin/gdal-warp-bindings/java/core/target/scala-2.11/classes ...
[warn] /Users/daunnc/subversions/git/github/pomadchin/gdal-warp-bindings/java/core/src/main/scala/com/azavea/gdal/GDALWarp.scala:21:2: method lines in trait ProcessBuilder is deprecated: Use lineStream instead.
[warn] @nativeLoader("gdaljni.0.0")
[warn]  ^
[warn] one warning found
[info] Done compiling.
[info] -- The C compiler identification is AppleClang 10.0.0.10001145
[info] -- The CXX compiler identification is AppleClang 10.0.0.10001145
[info] -- Check for working C compiler: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/cc
[info] -- Check for working C compiler: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/cc -- works
[info] -- Detecting C compiler ABI info
[info] -- Detecting C compiler ABI info - done
[info] -- Detecting C compile features
[info] -- Detecting C compile features - done
[info] -- Check for working CXX compiler: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++
[info] -- Check for working CXX compiler: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++ -- works
[info] -- Detecting CXX compiler ABI info
[info] -- Detecting CXX compiler ABI info - done
[info] -- Detecting CXX compile features
[info] -- Detecting CXX compile features - done
[info] -- Found JNI: /Library/Java/JavaVirtualMachines/jdk1.8.0_162.jdk/Contents/Home/jre/lib/libjawt.dylib  
[info] -- JNI include directories: /Library/Java/JavaVirtualMachines/jdk1.8.0_162.jdk/Contents/Home/include;/Library/Java/JavaVirtualMachines/jdk1.8.0_162.jdk/Contents/Home/include/darwin;/Library/Java/JavaVirtualMachines/jdk1.8.0_162.jdk/Contents/Home/include
[info] -- Found GDAL: /Library/Frameworks/gdal.framework  
[info] -- Configuring done
[info] -- Generating done
[error] CMake Warning (dev):
[error]   Policy CMP0068 is not set: RPATH settings on macOS do not affect
[error]   install_name.  Run "cmake --help-policy CMP0068" for policy details.  Use
[error]   the cmake_policy command to set the policy and suppress this warning.
[error]   For compatibility with older versions of CMake, the install_name fields for
[error]   the following targets are still affected by RPATH settings:
[error]    gdaljni.0.0
[error] This warning is for project developers.  Use -Wno-dev to suppress it.
[info] -- Build files have been written to: /Users/daunnc/subversions/git/github/pomadchin/gdal-warp-bindings/java/native/target/native/x86_64-darwin/build
[info] /usr/local/Cellar/cmake/3.11.0/bin/cmake -H/Users/daunnc/subversions/git/github/pomadchin/gdal-warp-bindings/java/native/src -B/Users/daunnc/subversions/git/github/pomadchin/gdal-warp-bindings/java/native/target/native/x86_64-darwin/build --check-build-system CMakeFiles/Makefile.cmake 0
[info] /usr/local/Cellar/cmake/3.11.0/bin/cmake -E cmake_progress_start /Users/daunnc/subversions/git/github/pomadchin/gdal-warp-bindings/java/native/target/native/x86_64-darwin/build/CMakeFiles /Users/daunnc/subversions/git/github/pomadchin/gdal-warp-bindings/java/native/target/native/x86_64-darwin/build/CMakeFiles/progress.marks
[info] /Applications/Xcode.app/Contents/Developer/usr/bin/make -f CMakeFiles/Makefile2 all
[info] /Applications/Xcode.app/Contents/Developer/usr/bin/make -f CMakeFiles/gdaljni.0.0.dir/build.make CMakeFiles/gdaljni.0.0.dir/depend
[info] cd /Users/daunnc/subversions/git/github/pomadchin/gdal-warp-bindings/java/native/target/native/x86_64-darwin/build && /usr/local/Cellar/cmake/3.11.0/bin/cmake -E cmake_depends "Unix Makefiles" /Users/daunnc/subversions/git/github/pomadchin/gdal-warp-bindings/java/native/src /Users/daunnc/subversions/git/github/pomadchin/gdal-warp-bindings/java/native/src /Users/daunnc/subversions/git/github/pomadchin/gdal-warp-bindings/java/native/target/native/x86_64-darwin/build /Users/daunnc/subversions/git/github/pomadchin/gdal-warp-bindings/java/native/target/native/x86_64-darwin/build /Users/daunnc/subversions/git/github/pomadchin/gdal-warp-bindings/java/native/target/native/x86_64-darwin/build/CMakeFiles/gdaljni.0.0.dir/DependInfo.cmake --color=
[info] Dependee "/Users/daunnc/subversions/git/github/pomadchin/gdal-warp-bindings/java/native/target/native/x86_64-darwin/build/CMakeFiles/gdaljni.0.0.dir/DependInfo.cmake" is newer than depender "/Users/daunnc/subversions/git/github/pomadchin/gdal-warp-bindings/java/native/target/native/x86_64-darwin/build/CMakeFiles/gdaljni.0.0.dir/depend.internal".
[info] Dependee "/Users/daunnc/subversions/git/github/pomadchin/gdal-warp-bindings/java/native/target/native/x86_64-darwin/build/CMakeFiles/CMakeDirectoryInformation.cmake" is newer than depender "/Users/daunnc/subversions/git/github/pomadchin/gdal-warp-bindings/java/native/target/native/x86_64-darwin/build/CMakeFiles/gdaljni.0.0.dir/depend.internal".
[info] Scanning dependencies of target gdaljni.0.0
[info] /Applications/Xcode.app/Contents/Developer/usr/bin/make -f CMakeFiles/gdaljni.0.0.dir/build.make CMakeFiles/gdaljni.0.0.dir/build
[info] [ 50%] Building CXX object CMakeFiles/gdaljni.0.0.dir/Accessors.cpp.o
[info] /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++  -Dgdaljni_0_0_EXPORTS -I/Users/daunnc/subversions/git/github/pomadchin/gdal-warp-bindings/java/native/src/. -I/Users/daunnc/subversions/git/github/pomadchin/gdal-warp-bindings/java/native/src/include -I/Library/Java/JavaVirtualMachines/jdk1.8.0_162.jdk/Contents/Home/include -I/Library/Java/JavaVirtualMachines/jdk1.8.0_162.jdk/Contents/Home/include/darwin  -O3 -DNDEBUG -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk -fPIC   -o CMakeFiles/gdaljni.0.0.dir/Accessors.cpp.o -c /Users/daunnc/subversions/git/github/pomadchin/gdal-warp-bindings/java/native/src/Accessors.cpp
[info] [100%] Linking CXX shared library libgdaljni.0.0.dylib
[info] /usr/local/Cellar/cmake/3.11.0/bin/cmake -E cmake_link_script CMakeFiles/gdaljni.0.0.dir/link.txt --verbose=1
[info] /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++ -O3 -DNDEBUG -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk -dynamiclib -Wl,-headerpad_max_install_names  -o libgdaljni.0.0.dylib -install_name @rpath/libgdaljni.0.0.dylib CMakeFiles/gdaljni.0.0.dir/Accessors.cpp.o 
[info] [100%] Built target gdaljni.0.0
[info] /usr/local/Cellar/cmake/3.11.0/bin/cmake -E cmake_progress_start /Users/daunnc/subversions/git/github/pomadchin/gdal-warp-bindings/java/native/target/native/x86_64-darwin/build/CMakeFiles 0
[info] [100%] Built target gdaljni.0.0
[info] Install the project...
[info] -- Install configuration: "Release"
[info] -- Installing: /Users/daunnc/subversions/git/github/pomadchin/gdal-warp-bindings/java/native/target/native/x86_64-darwin/bin/./libgdaljni.0.0.dylib
[success] Library built in /Users/daunnc/subversions/git/github/pomadchin/gdal-warp-bindings/java/native/target/native/x86_64-darwin/bin/libgdaljni.0.0.dylib
[info] Compiling 1 Scala source to /Users/daunnc/subversions/git/github/pomadchin/gdal-warp-bindings/java/core/target/scala-2.11/test-classes ...
[info] Done compiling.
Libs were loaded as expected
[info] GDALWarpSpec:
[info] - Test that dylibs are laoded
[info] Run completed in 359 milliseconds.
[info] Total number of tests run: 1
[info] Suites: completed 1, aborted 0
[info] Tests: succeeded 1, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
[success] Total time: 8 s, completed Feb 19, 2019 10:35:11 PM
```

The thing is that [this line](https://github.com/jamesmcclain/gdal-warp-bindings/blob/master/java/native/src/CMakeLists.txt#L47) defines the name of the generated dynamic lib. In this case it's `libgdaljni.0.0.so`

If you'll change it to 

```bash
set (LIB_NAME ${PROJECT_NAME}${PROJECT_VERSION_MAJOR})
```

Then the old variant would work:

```scala
@nativeLoader("gdaljni0")
```
