### PR TITLE
Tokens, Number of Copies, Thread Safety

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ src/experiments/thread/wrapthread
 src/unit_tests/dataset_tests
 src/unit_tests/token_tests
 src/unit_tests/cache_tests
+src/unit_tests/bindings_tests
 src/com_azavea_gdal_GDALWarp.h
 *.jar
 *.class

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 src/experiments/bench/rawbench
 src/experiments/thread/rawthread
 src/experiments/thread/wrapthread
+src/experiments/thread/pattern
 src/unit_tests/dataset_tests
 src/unit_tests/token_tests
 src/unit_tests/cache_tests

--- a/.travis/tests.sh
+++ b/.travis/tests.sh
@@ -36,4 +36,4 @@ cp src/libgdalwarp_bindings.dylib src/main/java/resources/
 cp src/gdalwarp_bindings.dll src/main/java/resources/
 (cd src/main/java ; jar -cvf ../../../gdalwarp.jar com/azavea/gdal/*.class cz/adamh/utils/*.class resources/*)
 
-rm -f $(find | grep '\.\(o\|obj\|dylib\|dll\|so\)$')
+rm -f $(find | grep '\.\(o\|obj\|dylib\|dll\|so\|class\)$')

--- a/.travis/tests.sh
+++ b/.travis/tests.sh
@@ -6,7 +6,7 @@ docker run -it --rm \
       -v $(pwd):/workdir \
       -e CC=gcc -e CXX=g++ \
       -e JAVA_HOME="/usr/lib/jvm/java-8-openjdk-amd64" \
-      jamesmcclain/gdal-build-environment:3 make -C src tests
+      jamesmcclain/gdal-build-environment:3 make -C src tests || exit -1
 
 rm -f $(find | grep '\.o$')
 docker run -it --rm \
@@ -20,7 +20,7 @@ docker run -it --rm \
       -e CXXFLAGS="-I/usr/osxcross/SDK/MacOSX10.10.sdk/usr/include/c++/v1"  \
       -e BOOST_ROOT="/usr/local/include/boost_1_69_0" \
       -e LDFLAGS="-mmacosx-version-min=10.9 -L/macintosh/gdal/2.4.0_1/lib -lgdal -lstdc++ -lpthread" \
-      jamesmcclain/gdal-build-environment:3 make -C src libgdalwarp_bindings.dylib
+      jamesmcclain/gdal-build-environment:3 make -C src libgdalwarp_bindings.dylib || exit -1
 
 docker run -it --rm \
       -v $(pwd):/workdir \
@@ -30,10 +30,10 @@ docker run -it --rm \
       -e JAVA_HOME="/windows/jdk8u202-b08" \
       -e BOOST_ROOT="/usr/local/include/boost_1_69_0" \
       -e LDFLAGS="-L/windows/gdal/lib -lgdal_i -lstdc++ -lpthread -lws2_32" \
-      jamesmcclain/gdal-build-environment:3 make -C src gdalwarp_bindings.dll
+      jamesmcclain/gdal-build-environment:3 make -C src gdalwarp_bindings.dll || exit -1
 
-cp src/libgdalwarp_bindings.dylib src/main/java/resources/
-cp src/gdalwarp_bindings.dll src/main/java/resources/
-(cd src/main/java ; jar -cvf ../../../gdalwarp.jar com/azavea/gdal/*.class cz/adamh/utils/*.class resources/*)
+cp src/libgdalwarp_bindings.dylib src/main/java/resources/ || exit -1
+cp src/gdalwarp_bindings.dll src/main/java/resources/ || exit -1
+(cd src/main/java ; jar -cvf ../../../gdalwarp.jar com/azavea/gdal/*.class cz/adamh/utils/*.class resources/*) || exit -1
 
 rm -f $(find | grep '\.\(o\|obj\|dylib\|dll\|so\|class\)$')

--- a/src/Makefile
+++ b/src/Makefile
@@ -6,7 +6,7 @@ GDALCFLAGS ?= $(shell pkg-config gdal --cflags)
 BOOST_ROOT ?= /usr/include
 OS ?= linux
 SO ?= so
-HEADERS = bindings.h types.hpp flat_lru_cache.hpp lru_cache.hpp locked_dataset.hpp tokens.hpp
+HEADERS = bindings.h types.hpp flat_lru_cache.hpp locked_dataset.hpp tokens.hpp
 
 all: tests libgdalwarp_bindings.$(SO)
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,5 +1,5 @@
 CFLAGS ?= -Wall -Werror -O0 -ggdb3
-CXXFLAGS ?= -std=c++1z
+CXXFLAGS ?= -std=c++14
 LDFLAGS ?= $(shell pkg-config gdal --libs) -l:libstdc++.a -lpthread
 JAVA_HOME ?= /usr/lib/jvm/java-11-openjdk-amd64
 GDALCFLAGS ?= $(shell pkg-config gdal --cflags)

--- a/src/bindings.cpp
+++ b/src/bindings.cpp
@@ -97,10 +97,8 @@ void deinit()
 {
     if (cache != nullptr)
     {
-#if !defined(__MINGW32__)
-        fprintf(stderr, "%ld\n", cache->size());
-#endif
         delete cache;
+        cache = nullptr;
     }
     token_deinit();
 }

--- a/src/bindings.cpp
+++ b/src/bindings.cpp
@@ -37,7 +37,7 @@
 
 typedef flat_lru_cache cache_t;
 
-constexpr useconds_t MAX_US = (1 << 20);
+constexpr useconds_t MAX_US = (1 << 16);
 
 cache_t *cache = nullptr;
 
@@ -60,7 +60,11 @@ cache_t *cache = nullptr;
         int i;                                                     \
         for (i = 0; (i < attempts || attempts <= 0) && !done; ++i) \
         {                                                          \
-            auto locked_datasets = cache->get(uri_options);        \
+            auto locked_datasets = cache->get(uri_options, -4);    \
+            if (locked_datasets.size() == 0)                       \
+            {                                                      \
+                return -EAGAIN;                                    \
+            }                                                      \
             TRY(fn)                                                \
             useconds_t us = 1 << i;                                \
             usleep(us <= MAX_US ? us : MAX_US);                    \

--- a/src/bindings.cpp
+++ b/src/bindings.cpp
@@ -37,6 +37,8 @@
 
 typedef flat_lru_cache cache_t;
 
+constexpr useconds_t MAX_US = (1 << 20);
+
 cache_t *cache = nullptr;
 
 #define TRY(fn)                     \
@@ -60,7 +62,8 @@ cache_t *cache = nullptr;
         {                                                          \
             auto locked_datasets = cache->get(uri_options);        \
             TRY(fn)                                                \
-            sched_yield();                                         \
+            useconds_t us = 1 << i;                                \
+            usleep(us <= MAX_US ? us : MAX_US);                    \
         }                                                          \
         if (i < attempts || (i > 0 && attempts == 0))              \
         {                                                          \

--- a/src/bindings.cpp
+++ b/src/bindings.cpp
@@ -75,7 +75,7 @@ void init(size_t size, size_t copies)
         throw std::bad_alloc();
     }
 
-    token_init(size << 1);
+    token_init(640 * (1 << 10)); // This should be enough for anyone
 
     return;
 }

--- a/src/bindings.cpp
+++ b/src/bindings.cpp
@@ -76,13 +76,13 @@ cache_t *cache = nullptr;
         return -ENOENT;                                            \
     }
 
-void init(size_t size, size_t copies)
+void init(size_t size)
 {
     deinit();
 
     GDALAllRegister();
 
-    cache = new cache_t(size, copies);
+    cache = new cache_t(size);
     if (cache == nullptr)
     {
         throw std::bad_alloc();

--- a/src/bindings.h
+++ b/src/bindings.h
@@ -24,7 +24,7 @@ extern "C"
 {
 #endif
 
-    void init(size_t size, size_t copies);
+    void init(size_t size);
     void deinit();
 
     uint64_t get_token(const char *uri, const char **options);

--- a/src/com_azavea_gdal_GDALWarp.c
+++ b/src/com_azavea_gdal_GDALWarp.c
@@ -47,10 +47,10 @@ uint64_t htobe64(uint64_t x)
 const int MAX_OPTIONS = 1 << 10;
 int gc_lock = 0;
 
-JNIEXPORT void JNICALL Java_com_azavea_gdal_GDALWarp__1init(JNIEnv *env, jobject obj, jint size, jint copies)
+JNIEXPORT void JNICALL Java_com_azavea_gdal_GDALWarp__1init(JNIEnv *env, jobject obj, jint size)
 {
-    gc_lock = (getenv("GDALWARP_GC_LOCK") != NULL); // XXX enabling this might be unsafe
-    init(size, copies);
+    gc_lock = (getenv("GDALWARP_GC_LOCK") != NULL); // XXX enabling this might be unsafe but might lead to better performance
+    init(size);
 }
 
 JNIEXPORT void JNICALL Java_com_azavea_gdal_GDALWarp_deinit(JNIEnv *env, jobject obj)

--- a/src/com_azavea_gdal_GDALWarp.c
+++ b/src/com_azavea_gdal_GDALWarp.c
@@ -16,6 +16,7 @@
 
 #include <stdlib.h>
 #include <string.h>
+#include <errno.h>
 #if defined(__APPLE__)
 #include <arpa/inet.h>
 #define htobe16(x) htons(x)
@@ -27,10 +28,11 @@
 #define htobe16(x) htons(x)
 #define htobe32(x) htonl(x)
 
-uint64_t htobe64(uint64_t x) {
+uint64_t htobe64(uint64_t x)
+{
     uint64_t retval;
-    uint32_t * p1 = (uint32_t *)&retval;
-    uint32_t * p2 = (uint32_t *)&x;
+    uint32_t *p1 = (uint32_t *)&retval;
+    uint32_t *p2 = (uint32_t *)&x;
     p1[0] = htonl(p2[1]);
     p1[1] = htonl(p2[0]);
     return retval;
@@ -81,120 +83,120 @@ JNIEXPORT jlong JNICALL Java_com_azavea_gdal_GDALWarp_get_1token(JNIEnv *env, jo
     return token;
 }
 
-JNIEXPORT jboolean JNICALL Java_com_azavea_gdal_GDALWarp_get_1overview_1widths_1heights(JNIEnv *env, jclass obj,
-                                                                                        jlong token,
-                                                                                        jint dataset,
-                                                                                        jint attempts,
-                                                                                        jintArray _widths,
-                                                                                        jintArray _heights)
+JNIEXPORT jint JNICALL Java_com_azavea_gdal_GDALWarp_get_1overview_1widths_1heights(JNIEnv *env, jclass obj,
+                                                                                    jlong token,
+                                                                                    jint dataset,
+                                                                                    jint attempts,
+                                                                                    jintArray _widths,
+                                                                                    jintArray _heights)
 {
     jint *widths = (*env)->GetIntArrayElements(env, _widths, NULL);
     jint *heights = (*env)->GetIntArrayElements(env, _heights, NULL);
     int width_length = (*env)->GetArrayLength(env, _widths);
     int height_length = (*env)->GetArrayLength(env, _heights);
     int max_length = width_length < height_length ? width_length : height_length;
-    jboolean retval = get_overview_widths_heights(token, dataset, attempts, (int *)widths, (int *)heights, max_length);
+    jint retval = get_overview_widths_heights(token, dataset, attempts, (int *)widths, (int *)heights, max_length);
     (*env)->ReleaseIntArrayElements(env, _heights, heights, 0);
     (*env)->ReleaseIntArrayElements(env, _widths, widths, 0);
 
-    return retval;
+    return (retval == -ENOENT ? -1 : (retval == -EAGAIN ? 0 : retval));
 }
 
-JNIEXPORT jboolean JNICALL Java_com_azavea_gdal_GDALWarp_get_1crs_1proj4(JNIEnv *env, jclass obj,
-                                                                         jlong token,
-                                                                         jint dataset,
-                                                                         jint attempts,
-                                                                         jbyteArray _crs)
+JNIEXPORT jint JNICALL Java_com_azavea_gdal_GDALWarp_get_1crs_1proj4(JNIEnv *env, jclass obj,
+                                                                     jlong token,
+                                                                     jint dataset,
+                                                                     jint attempts,
+                                                                     jbyteArray _crs)
 {
     jbyte *crs = (*env)->GetByteArrayElements(env, _crs, NULL);
     int max_size = (*env)->GetArrayLength(env, _crs);
-    jboolean retval = get_crs_proj4(token, dataset, attempts, (char *)crs, max_size);
+    jint retval = get_crs_proj4(token, dataset, attempts, (char *)crs, max_size);
     (*env)->ReleaseByteArrayElements(env, _crs, crs, 0);
 
-    return retval;
+    return (retval == -ENOENT ? -1 : (retval == -EAGAIN ? 0 : retval));
 }
 
-JNIEXPORT jboolean JNICALL Java_com_azavea_gdal_GDALWarp_get_1crs_1wkt(JNIEnv *env, jclass obj,
+JNIEXPORT jint JNICALL Java_com_azavea_gdal_GDALWarp_get_1crs_1wkt(JNIEnv *env, jclass obj,
+                                                                   jlong token,
+                                                                   jint dataset,
+                                                                   jint attempts,
+                                                                   jbyteArray _crs)
+{
+    jbyte *crs = (*env)->GetByteArrayElements(env, _crs, NULL);
+    int max_size = (*env)->GetArrayLength(env, _crs);
+    jint retval = get_crs_wkt(token, dataset, attempts, (char *)crs, max_size);
+    (*env)->ReleaseByteArrayElements(env, _crs, crs, 0);
+
+    return (retval == -ENOENT ? -1 : (retval == -EAGAIN ? 0 : retval));
+}
+
+JNIEXPORT jint JNICALL Java_com_azavea_gdal_GDALWarp_get_1band_1nodata(JNIEnv *env, jclass obj,
                                                                        jlong token,
                                                                        jint dataset,
                                                                        jint attempts,
-                                                                       jbyteArray _crs)
+                                                                       jint band,
+                                                                       jdoubleArray _nodata,
+                                                                       jintArray _success)
 {
-    jbyte *crs = (*env)->GetByteArrayElements(env, _crs, NULL);
-    int max_size = (*env)->GetArrayLength(env, _crs);
-    jboolean retval = get_crs_wkt(token, dataset, attempts, (char *)crs, max_size);
-    (*env)->ReleaseByteArrayElements(env, _crs, crs, 0);
+    double *nodata = (*env)->GetDoubleArrayElements(env, _nodata, NULL);
+    jint *success = (*env)->GetIntArrayElements(env, _success, NULL);
+    jint retval = get_band_nodata(token, dataset, attempts, band, nodata, (int *)success);
+    (*env)->ReleaseIntArrayElements(env, _success, success, 0);
+    (*env)->ReleaseDoubleArrayElements(env, _nodata, nodata, 0);
 
-    return retval;
+    return (retval == -ENOENT ? -1 : (retval == -EAGAIN ? 0 : retval));
 }
 
-JNIEXPORT jboolean JNICALL Java_com_azavea_gdal_GDALWarp_get_1band_1nodata(JNIEnv *env, jclass obj,
+JNIEXPORT jint JNICALL Java_com_azavea_gdal_GDALWarp_get_1band_1data_1type(JNIEnv *env, jclass obj,
                                                                            jlong token,
                                                                            jint dataset,
                                                                            jint attempts,
                                                                            jint band,
-                                                                           jdoubleArray _nodata,
-                                                                           jintArray _success)
-{
-    double *nodata = (*env)->GetDoubleArrayElements(env, _nodata, NULL);
-    jint *success = (*env)->GetIntArrayElements(env, _success, NULL);
-    jboolean retval = get_band_nodata(token, dataset, attempts, band, nodata, (int *)success);
-    (*env)->ReleaseIntArrayElements(env, _success, success, 0);
-    (*env)->ReleaseDoubleArrayElements(env, _nodata, nodata, 0);
-
-    return retval;
-}
-
-JNIEXPORT jboolean JNICALL Java_com_azavea_gdal_GDALWarp_get_1band_1data_1type(JNIEnv *env, jclass obj,
-                                                                               jlong token,
-                                                                               jint dataset,
-                                                                               jint attempts,
-                                                                               jint band,
-                                                                               jintArray _data_type)
+                                                                           jintArray _data_type)
 {
     jint *data_type = (*env)->GetIntArrayElements(env, _data_type, NULL);
-    jboolean retval = get_band_data_type(token, dataset, attempts, band, (int *)data_type);
+    jint retval = get_band_data_type(token, dataset, attempts, band, (int *)data_type);
     (*env)->ReleaseIntArrayElements(env, _data_type, data_type, 0);
 
-    return retval;
+    return (retval == -ENOENT ? -1 : (retval == -EAGAIN ? 0 : retval));
 }
 
-JNIEXPORT jboolean JNICALL Java_com_azavea_gdal_GDALWarp_get_1band_1count(JNIEnv *env, jclass obj,
-                                                                          jlong token,
-                                                                          jint dataset,
-                                                                          jint attempts,
-                                                                          jintArray _band_count)
+JNIEXPORT jint JNICALL Java_com_azavea_gdal_GDALWarp_get_1band_1count(JNIEnv *env, jclass obj,
+                                                                      jlong token,
+                                                                      jint dataset,
+                                                                      jint attempts,
+                                                                      jintArray _band_count)
 {
     jint *band_count = (*env)->GetIntArrayElements(env, _band_count, NULL);
-    jboolean retval = get_band_count(token, dataset, attempts, (int *)band_count);
+    jint retval = get_band_count(token, dataset, attempts, (int *)band_count);
     (*env)->ReleaseIntArrayElements(env, _band_count, band_count, 0);
 
-    return retval;
+    return (retval == -ENOENT ? -1 : (retval == -EAGAIN ? 0 : retval));
 }
 
-jboolean JNICALL Java_com_azavea_gdal_GDALWarp_get_1width_1height(JNIEnv *env, jclass obj,
-                                                                  jlong token,
-                                                                  jint dataset,
-                                                                  jint attempts,
-                                                                  jintArray _width_height)
+jint JNICALL Java_com_azavea_gdal_GDALWarp_get_1width_1height(JNIEnv *env, jclass obj,
+                                                              jlong token,
+                                                              jint dataset,
+                                                              jint attempts,
+                                                              jintArray _width_height)
 {
     jint *width_height = (*env)->GetIntArrayElements(env, _width_height, NULL);
 
-    jboolean retval = get_width_height(token, dataset, attempts, (int *)width_height, (int *)(width_height + 1));
+    jint retval = get_width_height(token, dataset, attempts, (int *)width_height, (int *)(width_height + 1));
     (*env)->ReleaseIntArrayElements(env, _width_height, width_height, 0);
 
-    return retval;
+    return (retval == -ENOENT ? -1 : (retval == -EAGAIN ? 0 : retval));
 }
 
-JNIEXPORT jboolean JNICALL Java_com_azavea_gdal_GDALWarp_get_1data(JNIEnv *env, jobject obj,
-                                                                   jlong token,
-                                                                   jint dataset,
-                                                                   jint attempts,
-                                                                   jintArray _src_window,
-                                                                   jintArray _dst_window,
-                                                                   jint band_number,
-                                                                   jint type,
-                                                                   jbyteArray _data)
+JNIEXPORT jint JNICALL Java_com_azavea_gdal_GDALWarp_get_1data(JNIEnv *env, jobject obj,
+                                                               jlong token,
+                                                               jint dataset,
+                                                               jint attempts,
+                                                               jintArray _src_window,
+                                                               jintArray _dst_window,
+                                                               jint band_number,
+                                                               jint type,
+                                                               jbyteArray _data)
 {
     jint *src_window = (*env)->GetIntArrayElements(env, _src_window, NULL);
     jint *dst_window = (*env)->GetIntArrayElements(env, _dst_window, NULL);
@@ -209,7 +211,7 @@ JNIEXPORT jboolean JNICALL Java_com_azavea_gdal_GDALWarp_get_1data(JNIEnv *env, 
     {
         data = (*env)->GetByteArrayElements(env, _data, NULL);
     }
-    jboolean retval = get_data(token, dataset, attempts, (int *)src_window, (int *)dst_window, band_number, type, data);
+    jint retval = get_data(token, dataset, attempts, (int *)src_window, (int *)dst_window, band_number, type, data);
     switch (type)
     {
     case com_azavea_gdal_GDALWarp_GDT_Int16:
@@ -251,18 +253,18 @@ JNIEXPORT jboolean JNICALL Java_com_azavea_gdal_GDALWarp_get_1data(JNIEnv *env, 
     (*env)->ReleaseIntArrayElements(env, _dst_window, dst_window, JNI_ABORT);
     (*env)->ReleaseIntArrayElements(env, _src_window, src_window, JNI_ABORT);
 
-    return retval;
+    return (retval == -ENOENT ? -1 : (retval == -EAGAIN ? 0 : retval));
 }
 
-JNIEXPORT jboolean JNICALL Java_com_azavea_gdal_GDALWarp_get_1transform(JNIEnv *env, jclass obj,
-                                                                        jlong token,
-                                                                        jint dataset,
-                                                                        jint attempts,
-                                                                        jdoubleArray _transform)
+JNIEXPORT jint JNICALL Java_com_azavea_gdal_GDALWarp_get_1transform(JNIEnv *env, jclass obj,
+                                                                    jlong token,
+                                                                    jint dataset,
+                                                                    jint attempts,
+                                                                    jdoubleArray _transform)
 {
     double *transform = (*env)->GetDoubleArrayElements(env, _transform, NULL);
-    jboolean retval = get_transform(token, dataset, attempts, transform);
+    jint retval = get_transform(token, dataset, attempts, transform);
     (*env)->ReleaseDoubleArrayElements(env, _transform, transform, 0);
 
-    return retval;
+    return (retval == -ENOENT ? -1 : (retval == -EAGAIN ? 0 : retval));
 }

--- a/src/experiments/Makefile
+++ b/src/experiments/Makefile
@@ -1,10 +1,10 @@
 PORT ?= 8080
 NAME ?= gdal-warp-httpd
 
-.PHONY: httpd-start httpd-stop thread data thread/rawthread thread/wrapthread
-.SILENT: thread
+.PHONY: httpd-start httpd-stop tests data thread/rawthread thread/wrapthread
+.SILENT: tests
 
-all: thread clean cleaner cleanest
+all: tests cleaner
 
 httpd-start:
 	docker run -dit --rm --name $(NAME) -p $(PORT):80 -v $(shell pwd):/usr/local/apache2/htdocs/:ro httpd:2.4
@@ -47,7 +47,7 @@ thread/rawthread:
 thread/wrapthread:
 	make -C thread wrapthread
 
-thread: data thread/rawthread thread/wrapthread
+tests: data thread/rawthread thread/wrapthread
 	make -C . httpd-start
 	# LD_LIBRARY_PATH=$(LD_LIBRARY_PATH):$(shell pwd)/.. thread/rawthread data/c41078a1-local-local.vrt
 	# LD_LIBRARY_PATH=$(LD_LIBRARY_PATH):$(shell pwd)/.. thread/rawthread data/c41078a1-local-remote.vrt

--- a/src/experiments/thread/Makefile
+++ b/src/experiments/thread/Makefile
@@ -5,7 +5,7 @@ LDFLAGS ?= $(shell pkg-config gdal --libs) -L$(shell pwd) -lgdalwarp_bindings -l
 BOOST_ROOT ?= /usr/include
 SO ?= so
 
-all: rawthread wrapthread
+all: rawthread wrapthread pattern
 
 ../../libgdalwarp_bindings.$(SO):
 	make -C ../.. libgdalwarp_bindings.$(SO)
@@ -19,6 +19,9 @@ rawthread: rawthread.o libgdalwarp_bindings.$(SO)
 wrapthread: wrapthread.o libgdalwarp_bindings.$(SO)
 	$(CC) $< $(LDFLAGS) -o $@
 
+pattern: pattern.o libgdalwarp_bindings.$(SO)
+	$(CC) $< $(LDFLAGS) -o $@
+
 %.o: %.cpp
 	$(CXX) $(CFLAGS) $(CXXFLAGS) $(GDALCFLAGS) -I$(BOOST_ROOT) $< -c -o $@
 
@@ -26,6 +29,6 @@ clean:
 	rm -f *.o  libgdalwarp_bindings.$(SO)
 
 cleaner: clean
-	rm -f rawthread wrapthread
+	rm -f rawthread wrapthread pattern
 
 cleanest: cleaner

--- a/src/experiments/thread/pattern.cpp
+++ b/src/experiments/thread/pattern.cpp
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2019 Azavea
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cassert>
+#include <cstdio>
+#include <cstdlib>
+#include <cstdint>
+#include <random>
+
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <pthread.h>
+
+#include "../../bindings.h"
+#include "../../locked_dataset.hpp"
+
+// Strings
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wwrite-strings"
+const char *xres = "5";
+const char *yres = "7";
+char const *bad_uri = "HOPEFULLY_THERE_IS_NO_FILE_WITH_THIS_NAME";
+char const *options[] = {
+    "-tap", "-tr", xres, yres,
+    "-r", "bilinear",
+    "-t_srs", "epsg:3857",
+    nullptr};
+#pragma GCC diagnostic pop
+
+// Constants
+constexpr int N = (1024);
+constexpr int DIM = 1 << 8;
+constexpr int BUFFERSIZE = DIM * DIM;
+constexpr int ATTEMPTS = 1 << 20;
+
+// Threads
+int lg_steps = 12;
+pthread_t threads[N];
+
+// ANSI
+// Reference: https://stackoverflow.com/questions/3219393/stdlib-and-colored-output-in-c
+// Reference: https://en.wikipedia.org/wiki/ANSI_escape_code#Colors
+#define ANSI_COLOR_RED "\x1b[31;1m"
+#define ANSI_COLOR_GREEN "\x1b[32;1m"
+#define ANSI_COLOR_YELLOW "\x1b[33;1m"
+#define ANSI_COLOR_BLUE "\x1b[34;1m"
+#define ANSI_COLOR_MAGENTA "\x1b[35;1m"
+#define ANSI_COLOR_CYAN "\x1b[36;1m"
+#define ANSI_COLOR_RESET "\x1b[0m"
+
+void *reader(void *argv1)
+{
+    auto g = std::mt19937(std::random_device{}());
+    auto dist = std::uniform_int_distribution<int>(0, 999);
+    char *buf = static_cast<char *>(malloc(BUFFERSIZE));
+    double transform[6];
+    int scratch1, scratch2;
+    int src_window[4] = {0, 0, DIM, DIM};
+    int dst_window[2] = {DIM, DIM};
+
+    for (int k = 0; k < (1 << lg_steps); ++k)
+    {
+        uint64_t token;
+
+        switch (dist(g))
+        {
+        case 0:
+            token = 1; // Hopefully this is a bad token
+            break;
+        case 1:
+            token = get_token(bad_uri, options); // Hopefully this is a bad filename
+            break;
+        default:
+            token = get_token(static_cast<const char *>(argv1), options);
+        }
+
+        get_crs_wkt(token, token % 2, ATTEMPTS, buf, BUFFERSIZE);
+        get_crs_proj4(token, token % 2, ATTEMPTS, buf, BUFFERSIZE);
+        get_band_nodata(token, token % 2, ATTEMPTS, 1, transform, &scratch1);
+        get_width_height(token, token % 2, ATTEMPTS, &scratch1, &scratch2);
+        get_data(token, token % 2, ATTEMPTS, src_window, dst_window, 1, 1 /* GDT_Byte */, buf);
+    }
+
+    return nullptr;
+}
+
+bool keep_going = true;
+
+int main(int argc, char **argv)
+{
+    int n = N;
+
+    if (argc < 2)
+    {
+        exit(-1);
+    }
+    if (argc >= 3)
+    {
+        sscanf(argv[2], "%d", &lg_steps);
+        fprintf(stderr, ANSI_COLOR_BLUE "lg_steps = %d\n" ANSI_COLOR_RESET, lg_steps);
+    }
+    if (argc >= 4)
+    {
+        sscanf(argv[3], "%d", &n);
+        if (n > N || n < 0)
+        {
+            n = N;
+        }
+        fprintf(stderr, ANSI_COLOR_BLUE "n = %d\n" ANSI_COLOR_RESET, n);
+    }
+
+    // Setup
+
+    init(1 << 8);
+    dup2(open("/dev/null", O_WRONLY), 2);
+
+    for (int i = 0; i < n; ++i)
+    {
+        assert(pthread_create(&threads[i], nullptr, reader, argv[1]) == 0);
+    }
+    for (int i = 0; i < n; ++i)
+    {
+        assert(pthread_join(threads[i], nullptr) == 0);
+        fprintf(stdout, ANSI_COLOR_MAGENTA "." ANSI_COLOR_RESET);
+    }
+    fprintf(stdout, "\n");
+
+    deinit();
+
+    return 0;
+}

--- a/src/experiments/thread/wrapthread.cpp
+++ b/src/experiments/thread/wrapthread.cpp
@@ -220,7 +220,7 @@ int main(int argc, char **argv)
     GDALClose(dataset);
     GDALClose(source);
 
-    init(1 << 7, 1 << 5);
+    init(1 << 8);
     token = get_token(argv[1], const_cast<const char **>(actual_options));
     {
         t::auto_cpu_timer timer;

--- a/src/experiments/thread/wrapthread.cpp
+++ b/src/experiments/thread/wrapthread.cpp
@@ -109,7 +109,7 @@ void *reader(void *)
         int src_window[4] = {i * WINDOW_SIZE, j * WINDOW_SIZE, WINDOW_SIZE, WINDOW_SIZE};
         int dst_window[2] = {TILE_SIZE, TILE_SIZE};
 
-        if (get_data(token, 1, 0, src_window, dst_window, 1, GDT_Byte, buffer))
+        if (get_data(token, 1, 0, src_window, dst_window, 1, GDT_Byte, buffer) > 0)
         {
             auto s = std::string(reinterpret_cast<char *>(buffer));
             auto h = hash(s);

--- a/src/flat_lru_cache.hpp
+++ b/src/flat_lru_cache.hpp
@@ -17,9 +17,11 @@
 #ifndef __CACHE_HPP__
 #define __CACHE_HPP__
 
-#include <vector>
+#include <algorithm>
 #include <cstddef>
 #include <cstdint>
+#include <random>
+#include <vector>
 
 #include <pthread.h>
 
@@ -44,6 +46,7 @@ class flat_lru_cache
           m_size(0),
           m_lock(PTHREAD_RWLOCK_INITIALIZER)
     {
+        g = std::mt19937(std::random_device{}());
         clear();
     }
 
@@ -136,6 +139,10 @@ class flat_lru_cache
                 m_atimes[i] = current_time;
             }
         }
+        if (return_list.size() > 1)
+        {
+            std::shuffle(return_list.begin(), return_list.end(), g);
+        }
         pthread_rwlock_unlock(&m_lock);
 
         if (return_list.size() < 1) // Try hard to return at least one
@@ -216,6 +223,7 @@ class flat_lru_cache
     std::vector<size_t> m_tags;
     std::vector<atime_t> m_atimes;
     std::vector<value_t> m_values;
+    std::mt19937 g;
     atime_t m_time;
     size_t m_capacity;
     size_t m_copies;

--- a/src/flat_lru_cache.hpp
+++ b/src/flat_lru_cache.hpp
@@ -191,11 +191,20 @@ class flat_lru_cache
         }
         if (best_index != -1)
         {
-            m_tags[best_index] = tag;
-            m_atimes[best_index] = current_time;
-            m_values[best_index] = locked_dataset(key);
-            m_size++;
-            return &(m_values[best_index]);
+            auto ds = locked_dataset(key);
+
+            if (ds.valid())
+            {
+                m_tags[best_index] = tag;
+                m_atimes[best_index] = current_time;
+                m_values[best_index] = std::move(ds);
+                m_size++;
+                return &(m_values[best_index]);
+            }
+            else
+            {
+                return nullptr;
+            }
         }
         else
         {

--- a/src/locked_dataset.hpp
+++ b/src/locked_dataset.hpp
@@ -404,6 +404,14 @@ class locked_dataset
         pthread_rwlock_unlock(&m_use_count);
     }
 
+    /**
+     * Prepare for deletion (use only if previously locked for deletion).
+     */
+    void prepare_for_deletion()
+    {
+        pthread_rwlock_unlock(&m_use_count);
+    }
+
   private:
     /**
      * A function to open a GDAL dataset answering the given warp

--- a/src/locked_dataset.hpp
+++ b/src/locked_dataset.hpp
@@ -467,18 +467,21 @@ class locked_dataset
      */
     void close()
     {
-        pthread_mutex_lock(&m_lock);
-        if (m_datasets[WARPED] != nullptr)
+        if (valid())
         {
-            GDALClose(m_datasets[WARPED]);
-            m_datasets[WARPED] = nullptr;
+            pthread_mutex_lock(&m_lock);
+            if (m_datasets[WARPED] != nullptr)
+            {
+                GDALClose(m_datasets[WARPED]);
+                m_datasets[WARPED] = nullptr;
+            }
+            if (m_datasets[SOURCE] != nullptr)
+            {
+                GDALClose(m_datasets[SOURCE]);
+                m_datasets[SOURCE] = nullptr;
+            }
+            pthread_mutex_unlock(&m_lock);
         }
-        if (m_datasets[SOURCE] != nullptr)
-        {
-            GDALClose(m_datasets[SOURCE]);
-            m_datasets[SOURCE] = nullptr;
-        }
-        pthread_mutex_unlock(&m_lock);
     }
 
   public:

--- a/src/locked_dataset.hpp
+++ b/src/locked_dataset.hpp
@@ -447,11 +447,7 @@ class locked_dataset
                 return; // Lock intentionally not unlocked
             }
 
-#if !defined(__MINGW32__)
-            m_datasets[WARPED] = GDALWarp("/dev/null", nullptr, 1, &m_datasets[SOURCE], app_options, 0);
-#else
-            m_datasets[WARPED] = GDALWarp("nul", nullptr, 1, &m_datasets[SOURCE], app_options, 0);
-#endif
+            m_datasets[WARPED] = GDALWarp("", nullptr, 1, &m_datasets[SOURCE], app_options, 0);
             if (m_datasets[SOURCE] == nullptr)
             {
                 GDALClose(m_datasets[SOURCE]);

--- a/src/locked_dataset.hpp
+++ b/src/locked_dataset.hpp
@@ -42,7 +42,7 @@ class locked_dataset
     locked_dataset()
         : m_datasets{nullptr, nullptr},
           m_uri_options(),
-          m_lock(PTHREAD_MUTEX_INITIALIZER),
+          m_dataset_lock(PTHREAD_MUTEX_INITIALIZER),
           m_use_count(PTHREAD_RWLOCK_INITIALIZER)
     {
     }
@@ -50,7 +50,7 @@ class locked_dataset
     locked_dataset(const uri_options_t &uri_options)
         : m_datasets{nullptr, nullptr},
           m_uri_options(uri_options),
-          m_lock(PTHREAD_MUTEX_INITIALIZER),
+          m_dataset_lock(PTHREAD_MUTEX_INITIALIZER),
           m_use_count(PTHREAD_RWLOCK_INITIALIZER)
     {
         open();
@@ -59,7 +59,7 @@ class locked_dataset
     locked_dataset(const locked_dataset &rhs)
         : m_datasets{nullptr, nullptr},
           m_uri_options(rhs.m_uri_options),
-          m_lock(PTHREAD_MUTEX_INITIALIZER),
+          m_dataset_lock(PTHREAD_MUTEX_INITIALIZER),
           m_use_count(PTHREAD_RWLOCK_INITIALIZER)
     {
 #ifdef DEBUG
@@ -70,7 +70,7 @@ class locked_dataset
 
     locked_dataset(locked_dataset &&rhs) noexcept
         : m_uri_options(std::exchange(rhs.m_uri_options, uri_options_t())),
-          m_lock(std::exchange(rhs.m_lock, PTHREAD_MUTEX_INITIALIZER)),
+          m_dataset_lock(std::exchange(rhs.m_dataset_lock, PTHREAD_MUTEX_INITIALIZER)),
           m_use_count(std::exchange(rhs.m_use_count, PTHREAD_RWLOCK_INITIALIZER))
     {
         // XXX not thread safe, but the rhs should always be a
@@ -95,7 +95,7 @@ class locked_dataset
 
         m_datasets[SOURCE] = std::exchange(rhs.m_datasets[SOURCE], nullptr);
         m_datasets[WARPED] = std::exchange(rhs.m_datasets[WARPED], nullptr);
-        m_lock = std::exchange(rhs.m_lock, PTHREAD_MUTEX_INITIALIZER);
+        m_dataset_lock = std::exchange(rhs.m_dataset_lock, PTHREAD_MUTEX_INITIALIZER);
         m_use_count = std::exchange(rhs.m_use_count, PTHREAD_RWLOCK_INITIALIZER);
         m_uri_options = std::exchange(rhs.m_uri_options, uri_options_t());
 
@@ -126,7 +126,7 @@ class locked_dataset
      */
     bool get_overview_widths_heights(int dataset, int *widths, int *heights, int max_length)
     {
-        if (pthread_mutex_trylock(&m_lock) != 0)
+        if (pthread_mutex_trylock(&m_dataset_lock) != 0)
         {
             return false;
         }
@@ -142,7 +142,7 @@ class locked_dataset
         {
             widths[i] = heights[i] = -1;
         }
-        pthread_mutex_unlock(&m_lock);
+        pthread_mutex_unlock(&m_dataset_lock);
         return true;
     }
 
@@ -156,7 +156,7 @@ class locked_dataset
      */
     bool get_crs_proj4(int dataset, char *crs, int max_size)
     {
-        if (pthread_mutex_trylock(&m_lock) != 0)
+        if (pthread_mutex_trylock(&m_dataset_lock) != 0)
         {
             return false;
         }
@@ -165,7 +165,7 @@ class locked_dataset
         OSRExportToProj4(ref, &result);
         strncpy(crs, result, max_size);
         CPLFree(result);
-        pthread_mutex_unlock(&m_lock);
+        pthread_mutex_unlock(&m_dataset_lock);
         return true;
     }
 
@@ -179,12 +179,12 @@ class locked_dataset
      */
     bool get_crs_wkt(int dataset, char *crs, int max_size)
     {
-        if (pthread_mutex_trylock(&m_lock) != 0)
+        if (pthread_mutex_trylock(&m_dataset_lock) != 0)
         {
             return false;
         }
         strncpy(crs, GDALGetProjectionRef(m_datasets[dataset]), max_size);
-        pthread_mutex_unlock(&m_lock);
+        pthread_mutex_unlock(&m_dataset_lock);
         return true;
     }
 
@@ -200,13 +200,13 @@ class locked_dataset
      */
     bool get_band_nodata(int dataset, int band, double *nodata, int *success)
     {
-        if (pthread_mutex_trylock(&m_lock) != 0)
+        if (pthread_mutex_trylock(&m_dataset_lock) != 0)
         {
             return false;
         }
         GDALRasterBandH bandh = GDALGetRasterBand(m_datasets[dataset], band);
         *nodata = GDALGetRasterNoDataValue(bandh, success);
-        pthread_mutex_unlock(&m_lock);
+        pthread_mutex_unlock(&m_dataset_lock);
         return true;
     }
 
@@ -221,13 +221,13 @@ class locked_dataset
      */
     bool get_band_data_type(int dataset, int band, GDALDataType *data_type)
     {
-        if (pthread_mutex_trylock(&m_lock) != 0)
+        if (pthread_mutex_trylock(&m_dataset_lock) != 0)
         {
             return false;
         }
         GDALRasterBandH bandh = GDALGetRasterBand(m_datasets[dataset], band);
         *data_type = GDALGetRasterDataType(bandh);
-        pthread_mutex_unlock(&m_lock);
+        pthread_mutex_unlock(&m_dataset_lock);
         return true;
     }
 
@@ -241,12 +241,12 @@ class locked_dataset
      */
     bool get_band_count(int dataset, int *band_count) const
     {
-        if (pthread_mutex_trylock(&m_lock) != 0)
+        if (pthread_mutex_trylock(&m_dataset_lock) != 0)
         {
             return false;
         }
         *band_count = GDALGetRasterCount(m_datasets[dataset]);
-        pthread_mutex_unlock(&m_lock);
+        pthread_mutex_unlock(&m_dataset_lock);
         return true;
     }
 
@@ -259,12 +259,12 @@ class locked_dataset
      */
     bool get_transform(int dataset, double transform[6]) const
     {
-        if (pthread_mutex_trylock(&m_lock) != 0)
+        if (pthread_mutex_trylock(&m_dataset_lock) != 0)
         {
             return false;
         }
         GDALGetGeoTransform(m_datasets[dataset], transform);
-        pthread_mutex_unlock(&m_lock);
+        pthread_mutex_unlock(&m_dataset_lock);
         return true;
     }
 
@@ -278,7 +278,7 @@ class locked_dataset
      */
     bool get_width_height(int dataset, int *width, int *height)
     {
-        if (pthread_mutex_trylock(&m_lock) != 0)
+        if (pthread_mutex_trylock(&m_dataset_lock) != 0)
         {
             return false;
         }
@@ -286,7 +286,7 @@ class locked_dataset
         auto ds = m_datasets[dataset];
         *width = GDALGetRasterXSize(ds);
         *height = GDALGetRasterYSize(ds);
-        pthread_mutex_unlock(&m_lock);
+        pthread_mutex_unlock(&m_dataset_lock);
 
         return true;
     }
@@ -317,7 +317,7 @@ class locked_dataset
     {
         GDALRasterBandH band = GDALGetRasterBand(m_datasets[dataset], band_number);
 
-        if (pthread_mutex_trylock(&m_lock) != 0)
+        if (pthread_mutex_trylock(&m_dataset_lock) != 0)
         {
             return false;
         }
@@ -332,7 +332,7 @@ class locked_dataset
             type,                         // destination type
             0, 0                          // stride
         );
-        pthread_mutex_unlock(&m_lock);
+        pthread_mutex_unlock(&m_dataset_lock);
 
         if (retval != CE_None)
         {
@@ -419,7 +419,7 @@ class locked_dataset
      */
     void open()
     {
-        pthread_mutex_lock(&m_lock);
+        pthread_mutex_lock(&m_dataset_lock);
         auto src = m_datasets[SOURCE];
         auto warped = m_datasets[WARPED];
         if (src == nullptr || warped == nullptr)
@@ -466,7 +466,7 @@ class locked_dataset
 
             GDALWarpAppOptionsFree(app_options);
         }
-        pthread_mutex_unlock(&m_lock);
+        pthread_mutex_unlock(&m_dataset_lock);
     }
 
     /**
@@ -477,7 +477,7 @@ class locked_dataset
     {
         if (valid())
         {
-            pthread_mutex_lock(&m_lock);
+            pthread_mutex_lock(&m_dataset_lock);
             if (m_datasets[WARPED] != nullptr)
             {
                 GDALClose(m_datasets[WARPED]);
@@ -488,7 +488,7 @@ class locked_dataset
                 GDALClose(m_datasets[SOURCE]);
                 m_datasets[SOURCE] = nullptr;
             }
-            pthread_mutex_unlock(&m_lock);
+            pthread_mutex_unlock(&m_dataset_lock);
         }
     }
 
@@ -499,7 +499,7 @@ class locked_dataset
   private:
     GDALDatasetH m_datasets[2];
     uri_options_t m_uri_options;
-    mutable pthread_mutex_t m_lock;
+    mutable pthread_mutex_t m_dataset_lock;
     mutable pthread_rwlock_t m_use_count;
 };
 

--- a/src/main/GDALWarpThreadTest.java
+++ b/src/main/GDALWarpThreadTest.java
@@ -74,8 +74,11 @@ class GDALWarpThreadTest extends Thread {
             src_window[0] = i * WINDOW_SIZE;
             src_window[1] = j * WINDOW_SIZE;
 
-            boolean success = GDALWarp.get_data(token, GDALWarp.WARPED, 0, src_window, dst_window, 1, GDALWarp.GDT_Byte,
-                    data);
+            int return_code = GDALWarp.get_data(token, /* */
+                    GDALWarp.WARPED, 0, /* */
+                    src_window, dst_window, 1, /* */
+                    GDALWarp.GDT_Byte, data);
+            boolean success = return_code > 0;
             int h = data.hashCode();
             assert (success == true);
             assert (h == EXPECTED[i + j * x]);
@@ -194,8 +197,11 @@ class GDALWarpThreadTest extends Thread {
                 for (int j = 0; j < y; ++j) {
                     src_window[0] = i * WINDOW_SIZE;
                     src_window[1] = j * WINDOW_SIZE;
-                    boolean success = GDALWarp.get_data(token, GDALWarp.WARPED, 0, src_window, dst_window, 1,
+                    int return_code = GDALWarp.get_data(token, /* */
+                            GDALWarp.WARPED, 0, /* */
+                            src_window, dst_window, 1, /* */
                             GDALWarp.GDT_Byte, data);
+                    boolean success = (return_code > 0);
                     assert (success == true);
                     EXPECTED[i + j * x] = data.hashCode();
                 }

--- a/src/main/java/com/azavea/gdal/GDALWarp.java
+++ b/src/main/java/com/azavea/gdal/GDALWarp.java
@@ -79,28 +79,28 @@ public class GDALWarp {
 
         public static native long get_token(String uri, String[] options);
 
-        public static native boolean get_overview_widths_heights(long token, int dataset, int attempts, /* */
+        public static native int get_overview_widths_heights(long token, int dataset, int attempts, /* */
                         int[] widths, int heights[]);
 
-        public static native boolean get_crs_proj4(long token, int dataset, int attempts, /* */
+        public static native int get_crs_proj4(long token, int dataset, int attempts, /* */
                         byte[] crs);
 
-        public static native boolean get_crs_wkt(long token, int dataset, int attempts, /* */
+        public static native int get_crs_wkt(long token, int dataset, int attempts, /* */
                         byte[] crs);
 
-        public static native boolean get_band_nodata(long token, int dataset, int attempts, /* */
+        public static native int get_band_nodata(long token, int dataset, int attempts, /* */
                         int band, double[] nodata, int[] success);
 
-        public static native boolean get_band_data_type(long token, int dataset, int attempts, /* */
+        public static native int get_band_data_type(long token, int dataset, int attempts, /* */
                         int band, int[] data_type);
 
-        public static native boolean get_band_count(long token, int dataset, int attempts, /* */
+        public static native int get_band_count(long token, int dataset, int attempts, /* */
                         int[] band_count);
 
-        public static native boolean get_width_height(long token, int dataset, int attempts, /* */
+        public static native int get_width_height(long token, int dataset, int attempts, /* */
                         int[] width_height);
 
-        public static native boolean get_data( /* */
+        public static native int get_data( /* */
                         long token, /* */
                         int dataset, /* */
                         int attemps, /* */
@@ -110,6 +110,6 @@ public class GDALWarp {
                         int type, /* */
                         byte[] data);
 
-        public static native boolean get_transform(long token, int dataset, int attempts, /* */
+        public static native int get_transform(long token, int dataset, int attempts, /* */
                         double[] transform);
 }

--- a/src/main/java/com/azavea/gdal/GDALWarp.java
+++ b/src/main/java/com/azavea/gdal/GDALWarp.java
@@ -43,9 +43,9 @@ public class GDALWarp {
         private static final String ANSI_RESET = "\u001B[0m";
         private static final String ANSI_RED = "\u001B[31m";
 
-        private static native void _init(int size, int copies);
+        private static native void _init(int size);
 
-        public static void init(int size, int copies) throws Exception {
+        public static void init(int size) throws Exception {
 
                 String os = System.getProperty("os.name").toLowerCase();
 
@@ -64,12 +64,12 @@ public class GDALWarp {
                         throw new Exception("Unsupported platform");
                 }
 
-                _init(size, copies);
+                _init(size);
         }
 
         static {
                 try {
-                        init(1 << 8, 1 << 4);
+                        init(1 << 8);
                 } catch (Exception e) {
                         System.err.println(ANSI_RED + "INITIALIZATION FAILED" + ANSI_RESET);
                 }

--- a/src/tokens.cpp
+++ b/src/tokens.cpp
@@ -25,7 +25,7 @@
 
 typedef boost::compute::detail::lru_cache<token_t, uri_options_t> lru_cache;
 static pthread_mutex_t token_lock;
-static lru_cache *cache;
+static lru_cache *cache = nullptr;
 
 void token_init(size_t size)
 {
@@ -37,7 +37,11 @@ void token_init(size_t size)
 
 void token_deinit()
 {
-    delete cache;
+    if (cache != nullptr)
+    {
+        delete cache;
+    }
+    cache = nullptr;
 }
 
 static token_t generate_token()

--- a/src/tokens.hpp
+++ b/src/tokens.hpp
@@ -24,6 +24,6 @@ void token_init(size_t size);
 void token_deinit();
 boost::optional<uri_options_t> query_token(uint64_t token);
 
-// The prototypes for get_token and surrender_token are in bindings.h
+// The prototypes for get_token are in bindings.h
 
 #endif

--- a/src/unit_tests/Makefile
+++ b/src/unit_tests/Makefile
@@ -9,10 +9,11 @@ SO ?= so
 .PHONY: tests clean cleaner cleanest
 .SILENT: tests
 
-tests: ../libgdalwarp_bindings.$(SO) ../experiments/data/c41078a1.tif token_tests dataset_tests cache_tests
+tests: ../libgdalwarp_bindings.$(SO) ../experiments/data/c41078a1.tif token_tests dataset_tests cache_tests bindings_tests
 	LD_LIBRARY_PATH=$(LD_LIBRARY_PATH):.. ./token_tests
 	LD_LIBRARY_PATH=$(LD_LIBRARY_PATH):.. ./dataset_tests
 	LD_LIBRARY_PATH=$(LD_LIBRARY_PATH):.. ./cache_tests
+	LD_LIBRARY_PATH=$(LD_LIBRARY_PATH):.. ./bindings_tests
 
 ../experiments/data/c41078a1.tif:
 	make -C ../experiments data/c41078a1.tif
@@ -28,6 +29,9 @@ dataset_tests: dataset_tests.cpp ../libgdalwarp_bindings.$(SO)
 
 cache_tests: cache_tests.cpp ../libgdalwarp_bindings.$(SO)
 	$(CXX) $(CFLAGS) $(GDALCFLAGS) $(CXXFLAGS) -I$(BOOST_ROOT) $< $(LDFLAGS) -lm -o $@
+
+bindings_tests: bindings_tests.cpp ../libgdalwarp_bindings.$(SO)
+	$(CXX) $(CFLAGS) $(GDALCFLAGS) $(CXXFLAGS) $< $(LDFLAGS) -lm -o $@
 
 clean:
 	rm -f *_tests

--- a/src/unit_tests/bindings_tests.cpp
+++ b/src/unit_tests/bindings_tests.cpp
@@ -36,13 +36,13 @@ const char *bad_uri = "HOPEFULLY_THERE_IS_NO_FILE_WITH_THIS_NAME.tif";
 
 BOOST_AUTO_TEST_CASE(initialization)
 {
-    init(1 << 7, 1 << 2);
+    init(1 << 8);
     deinit();
 }
 
 BOOST_AUTO_TEST_CASE(good_uri_finite_attempts_example)
 {
-    init(1 << 7, 1 << 2);
+    init(1 << 8);
 
     auto token = get_token(good_uri, options);
     double nodata;
@@ -60,7 +60,7 @@ BOOST_AUTO_TEST_CASE(good_uri_finite_attempts_example)
 
 BOOST_AUTO_TEST_CASE(good_uri_infinite_attempts_example)
 {
-    init(1 << 7, 1 << 2);
+    init(1 << 8);
 
     auto token = get_token(good_uri, options);
     double nodata;
@@ -78,7 +78,7 @@ BOOST_AUTO_TEST_CASE(good_uri_infinite_attempts_example)
 
 BOOST_AUTO_TEST_CASE(bad_uri_finite_attempts_example)
 {
-    init(1 << 7, 1 << 2);
+    init(1 << 8);
 
     auto token = get_token(bad_uri, options);
     double nodata;
@@ -92,7 +92,7 @@ BOOST_AUTO_TEST_CASE(bad_uri_finite_attempts_example)
 
 BOOST_AUTO_TEST_CASE(bad_token_finite_attempts_example)
 {
-    init(1 << 7, 1 << 2);
+    init(1 << 8);
 
     uint64_t token = 93;
     double nodata;
@@ -106,7 +106,7 @@ BOOST_AUTO_TEST_CASE(bad_token_finite_attempts_example)
 
 BOOST_AUTO_TEST_CASE(bad_token_infinite_attempts_example)
 {
-    init(1 << 7, 1 << 2);
+    init(1 << 8);
 
     uint64_t token = 93;
     double nodata;

--- a/src/unit_tests/bindings_tests.cpp
+++ b/src/unit_tests/bindings_tests.cpp
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2019 Azavea
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#define BOOST_TEST_MODULE Bindings Unit Tests
+#include <boost/test/included/unit_test.hpp>
+
+#include <errno.h>
+
+#include "bindings.h"
+#include "locked_dataset.hpp"
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wwrite-strings"
+const char *options[] = {
+    "-tap", "-tr", "7", "11",
+    "-r", "bilinear",
+    "-t_srs", "epsg:3857",
+    "-dstnodata", "107",
+    nullptr};
+const char *good_uri = "../experiments/data/c41078a1.tif";
+const char *bad_uri = "HOPEFULLY_THERE_IS_NO_FILE_WITH_THIS_NAME.tif";
+#pragma GCC diagnostic pop
+
+BOOST_AUTO_TEST_CASE(initialization)
+{
+    init(1 << 7, 1 << 2);
+    deinit();
+}
+
+BOOST_AUTO_TEST_CASE(good_uri_finite_attempts_example)
+{
+    init(1 << 7, 1 << 2);
+
+    auto token = get_token(good_uri, options);
+    double nodata;
+    int success;
+
+    BOOST_TEST(get_band_nodata(token, locked_dataset::SOURCE, 42, 1, &nodata, &success) > 0);
+    BOOST_TEST(success == 0);
+
+    BOOST_TEST(get_band_nodata(token, locked_dataset::WARPED, 42, 1, &nodata, &success) > 0);
+    BOOST_TEST(success != 0);
+    BOOST_TEST(nodata == 107.0);
+
+    deinit();
+}
+
+BOOST_AUTO_TEST_CASE(good_uri_infinite_attempts_example)
+{
+    init(1 << 7, 1 << 2);
+
+    auto token = get_token(good_uri, options);
+    double nodata;
+    int success;
+
+    BOOST_TEST(get_band_nodata(token, locked_dataset::SOURCE, 0, 1, &nodata, &success) > 0);
+    BOOST_TEST(success == 0);
+
+    BOOST_TEST(get_band_nodata(token, locked_dataset::WARPED, 0, 1, &nodata, &success) > 0);
+    BOOST_TEST(success != 0);
+    BOOST_TEST(nodata == 107.0);
+
+    deinit();
+}
+
+BOOST_AUTO_TEST_CASE(bad_uri_finite_attempts_example)
+{
+    init(1 << 7, 1 << 2);
+
+    auto token = get_token(bad_uri, options);
+    double nodata;
+    int success;
+
+    BOOST_TEST(get_band_nodata(token, locked_dataset::SOURCE, 3, 1, &nodata, &success) == -EAGAIN);
+    BOOST_TEST(get_band_nodata(token, locked_dataset::WARPED, 4, 1, &nodata, &success) == -EAGAIN);
+
+    deinit();
+}
+
+BOOST_AUTO_TEST_CASE(bad_token_finite_attempts_example)
+{
+    init(1 << 7, 1 << 2);
+
+    uint64_t token = 93;
+    double nodata;
+    int success;
+
+    BOOST_TEST(get_band_nodata(token, locked_dataset::SOURCE, 42, 1, &nodata, &success) == -ENOENT);
+    BOOST_TEST(get_band_nodata(token, locked_dataset::WARPED, 42, 1, &nodata, &success) == -ENOENT);
+
+    deinit();
+}
+
+BOOST_AUTO_TEST_CASE(bad_token_infinite_attempts_example)
+{
+    init(1 << 7, 1 << 2);
+
+    uint64_t token = 93;
+    double nodata;
+    int success;
+
+    BOOST_TEST(get_band_nodata(token, locked_dataset::SOURCE, 0, 1, &nodata, &success) == -ENOENT);
+    BOOST_TEST(get_band_nodata(token, locked_dataset::WARPED, 0, 1, &nodata, &success) == -ENOENT);
+
+    deinit();
+}

--- a/src/unit_tests/bindings_tests.cpp
+++ b/src/unit_tests/bindings_tests.cpp
@@ -90,6 +90,20 @@ BOOST_AUTO_TEST_CASE(bad_uri_finite_attempts_example)
     deinit();
 }
 
+BOOST_AUTO_TEST_CASE(bad_uri_infinite_attempts_example)
+{
+    init(1 << 8);
+
+    auto token = get_token(bad_uri, options);
+    double nodata;
+    int success;
+
+    BOOST_TEST(get_band_nodata(token, locked_dataset::SOURCE, 0, 1, &nodata, &success) == -EAGAIN);
+    BOOST_TEST(get_band_nodata(token, locked_dataset::WARPED, 0, 1, &nodata, &success) == -EAGAIN);
+
+    deinit();
+}
+
 BOOST_AUTO_TEST_CASE(bad_token_finite_attempts_example)
 {
     init(1 << 8);

--- a/src/unit_tests/cache_tests.cpp
+++ b/src/unit_tests/cache_tests.cpp
@@ -124,11 +124,34 @@ BOOST_AUTO_TEST_CASE(evict_correct_test)
 
 BOOST_AUTO_TEST_CASE(eager_multiple_test)
 {
-    auto cache = flat_lru_cache(5, 4);
-    cache.get(uri_options1, true);
-    cache.get(uri_options1, true);
-    cache.get(uri_options1, true);
-    cache.get(uri_options1, true);
-    cache.get(uri_options1, false);
+    auto cache = flat_lru_cache(8);
+    cache.get(uri_options1, 1);
+    BOOST_TEST(cache.count(uri_options1) == 1);
+    cache.get(uri_options1, 4);
     BOOST_TEST(cache.count(uri_options1) == 4);
+    cache.get(uri_options1, 8);
+    BOOST_TEST(cache.count(uri_options1) == 8);
+    cache.get(uri_options1, 16);
+    BOOST_TEST(cache.count(uri_options1) == 8);
+}
+
+BOOST_AUTO_TEST_CASE(zero_multiple_test)
+{
+    auto cache = flat_lru_cache(8);
+    BOOST_TEST(cache.count(uri_options1) == 0);
+    cache.get(uri_options1, 0);
+    BOOST_TEST(cache.count(uri_options1) == 0);
+}
+
+BOOST_AUTO_TEST_CASE(passive_multiple_test)
+{
+    auto cache = flat_lru_cache(8);
+    cache.get(uri_options1, 1);
+    BOOST_TEST(cache.count(uri_options1) <= 1);
+    cache.get(uri_options1, 4);
+    BOOST_TEST(cache.count(uri_options1) <= 4);
+    cache.get(uri_options1, 8);
+    BOOST_TEST(cache.count(uri_options1) <= 8);
+    cache.get(uri_options1, 16);
+    BOOST_TEST(cache.count(uri_options1) <= 8);
 }

--- a/src/unit_tests/token_tests.cpp
+++ b/src/unit_tests/token_tests.cpp
@@ -58,7 +58,7 @@ BOOST_AUTO_TEST_CASE(get_same_token_test)
     auto token2 = get_token(uri1, options1);
 
     BOOST_TEST(token1 == static_cast<token_t>(33));
-    BOOST_TEST(token1 == token2);
+    BOOST_TEST(token1 != token2);
     token_deinit();
 }
 
@@ -82,25 +82,6 @@ BOOST_AUTO_TEST_CASE(get_different_options_tokens_test)
     BOOST_TEST(token1 == static_cast<token_t>(33));
     BOOST_TEST(token1 != token2);
     token_deinit();
-}
-
-BOOST_AUTO_TEST_CASE(different_and_same_test)
-{
-    token_init(16);
-    auto token0 = get_token(uri2, options2);
-    auto token1 = get_token(uri1, options1);
-    auto token2 = get_token(uri1, options1);
-    auto token3 = get_token(uri2, options1);
-    auto token4 = get_token(uri2, options1);
-    auto token5 = get_token(uri1, options1);
-
-    BOOST_TEST(token1 == token2);
-    BOOST_TEST(token2 != token3);
-    BOOST_TEST(token3 == token4);
-    BOOST_TEST(token4 != token5);
-    BOOST_TEST(token5 == token1);
-    BOOST_TEST(token0 != token1);
-    BOOST_TEST(token0 != token3);
 }
 
 BOOST_AUTO_TEST_CASE(token_eviction_test)

--- a/src/unit_tests/token_tests.cpp
+++ b/src/unit_tests/token_tests.cpp
@@ -113,29 +113,6 @@ BOOST_AUTO_TEST_CASE(token_lru_eviction_test)
     BOOST_TEST(query_token(token4).is_initialized() == true);
 }
 
-#if 0
-BOOST_AUTO_TEST_CASE(surrender_token_test)
-{
-    token_init(16);
-    auto token1 = get_token(uri1, options1);
-    surrender_token(token1);
-    auto token2 = get_token(uri2, options1);
-
-    BOOST_TEST(token2 == static_cast<token_t>(33));
-    token_deinit();
-}
-
-BOOST_AUTO_TEST_CASE(double_free_test)
-{
-    token_init(16);
-    auto token = get_token(uri1, options1);
-    surrender_token(token);
-    surrender_token(token);
-
-    token_deinit();
-}
-#endif
-
 namespace std
 {
 std::ostream &operator<<(std::ostream &out, const uri_options_t &rhs)

--- a/src/unit_tests/token_tests.cpp
+++ b/src/unit_tests/token_tests.cpp
@@ -17,6 +17,7 @@
 #define BOOST_TEST_MODULE Token Unit Tests
 #include <boost/test/included/unit_test.hpp>
 
+#include "bindings.h"
 #include "tokens.hpp"
 
 #pragma GCC diagnostic push
@@ -35,12 +36,6 @@ const char *options2[] = {
 const char *uri1 = "geo.tif";
 const char *uri2 = "geo2.tif";
 #pragma GCC diagnostic pop
-
-extern "C"
-{
-    uint64_t get_token(const char *uri, const char **option1);
-    void surrender_token(uint64_t token);
-}
 
 BOOST_AUTO_TEST_CASE(get_unique_token_test)
 {


### PR DESCRIPTION
![Bds-Transport-Board-Token-Image](https://user-images.githubusercontent.com/11281373/54484369-de381b00-483b-11e9-9efc-61012b36ed8c.jpg)

- Tokens are no longer reused: not reusing them does increase the cost of storing tokens (from a small amount to a larger small amount), but has no impact on the cost of using GDAL (except for the slightly higher cost of querying a larger set of tokens  [should be very marginal compared to I/O and other compute costs]).
- The number of copies of a particular (warped) dataset is now dynamic.
- Thread-safety related tweaks suggested by Helgrind and DRD have been made.
