### PR TITLE
Deadlocks, Livelocks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ src/experiments/bench/rawbench
 src/experiments/thread/rawthread
 src/experiments/thread/wrapthread
 src/experiments/thread/pattern
+src/experiments/thread/oversubscribe
 src/unit_tests/dataset_tests
 src/unit_tests/token_tests
 src/unit_tests/cache_tests

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 *.vrt
 .vscode/launch.json
 .vscode/c_cpp_properties.json
+.vscode/ipch
 src/experiments/bench/rawbench
 src/experiments/thread/rawthread
 src/experiments/thread/wrapthread

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ services:
 env:
    global:
       CLEAN_TRAVIS_TAG=${TRAVIS_TAG/[[:space:]]/}
-      COMMIT=${CLEAN_TRAVIS_TAG:-${TRAVIS_COMMIT:0:6}}
+      COMMIT=${CLEAN_TRAVIS_TAG:-${TRAVIS_COMMIT:0:7}}
       JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
 
 before_install:

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Intro #
 
 Having multi-threaded access to raster data is an important prerequisite to constructing a high-performance GIS tile server.
-If one wishes to use [GDAL's VRT functionality](https://www.gdal.org/gdal_vrttut.html) in this way, then it is necessary to ensure that no VRT dataset simultaneously used by more than one thread (even for read-only operations).
+If one wishes to use [GDAL's VRT functionality](https://www.gdal.org/gdal_vrttut.html) in this way, then it is necessary to ensure that no VRT dataset is simultaneously used by more than one thread, even for read-only operations.
 The code in this repository attempts to address that issue by wrapping GDAL datasets in objects which abstract one or more identical datasets; the wrapped datasets can be safely used from multiple threads with less contention than would be the case with a simple mutex around one GDAL dataset.
 APIs are provided for C and Java.
 

--- a/src/bindings.cpp
+++ b/src/bindings.cpp
@@ -24,9 +24,9 @@
 #include <vector>
 
 #include <errno.h>
-#include <sched.h>
 #include <unistd.h>
 #include <pthread.h>
+
 #include <gdal.h>
 
 #include "bindings.h"
@@ -37,7 +37,8 @@
 
 typedef flat_lru_cache cache_t;
 
-constexpr useconds_t MAX_US = (1 << 16);
+constexpr int TOO_MANY_ITERATIONS = (1 << 16);
+pthread_mutex_t livelock_mutex = PTHREAD_MUTEX_INITIALIZER;
 
 cache_t *cache = nullptr;
 
@@ -74,17 +75,33 @@ cache_t *cache = nullptr;
     if (query_result)                                              \
     {                                                              \
         auto uri_options = query_result.get();                     \
+        bool has_lock = false;                                     \
         int i;                                                     \
         for (i = 0; (i < attempts || attempts <= 0) && !done; ++i) \
         {                                                          \
+            if (i >= TOO_MANY_ITERATIONS && !has_lock)             \
+            {                                                      \
+                pthread_mutex_lock(&livelock_mutex);               \
+                has_lock = true;                                   \
+            }                                                      \
             auto locked_datasets = cache->get(uri_options, -4);    \
             if (locked_datasets.size() == 0)                       \
             {                                                      \
+                if (has_lock)                                      \
+                {                                                  \
+                    pthread_mutex_unlock(&livelock_mutex);         \
+                }                                                  \
                 return -EAGAIN;                                    \
             }                                                      \
             TRY(fn)                                                \
-            useconds_t us = 1 << i;                                \
-            usleep(us <= MAX_US ? us : MAX_US);                    \
+            if (!done && !has_lock)                                \
+            {                                                      \
+                sleep(0 + (i % 1009 == 0 ? 1 : 0));                \
+            }                                                      \
+        }                                                          \
+        if (has_lock)                                              \
+        {                                                          \
+            pthread_mutex_unlock(&livelock_mutex);                 \
         }                                                          \
         if (i < attempts || (i > 0 && attempts == 0))              \
         {                                                          \

--- a/src/bindings.cpp
+++ b/src/bindings.cpp
@@ -96,7 +96,7 @@ cache_t *cache = nullptr;
             TRY(fn)                                                \
             if (!done && !has_lock)                                \
             {                                                      \
-                sleep(0 + (i % 1009 == 0 ? 1 : 0));                \
+                sleep(0);                \
             }                                                      \
         }                                                          \
         if (has_lock)                                              \

--- a/src/bindings.cpp
+++ b/src/bindings.cpp
@@ -96,7 +96,7 @@ cache_t *cache = nullptr;
             TRY(fn)                                                \
             if (!done && !has_lock)                                \
             {                                                      \
-                sleep(0);                \
+                sleep(0);                                          \
             }                                                      \
         }                                                          \
         if (has_lock)                                              \

--- a/src/com_azavea_gdal_GDALWarp.c
+++ b/src/com_azavea_gdal_GDALWarp.c
@@ -158,7 +158,7 @@ JNIEXPORT jint JNICALL Java_com_azavea_gdal_GDALWarp_get_1band_1min_1max(JNIEnv 
 {
     double *minmax = (*env)->GetDoubleArrayElements(env, _minmax, NULL);
     jint *success = (*env)->GetIntArrayElements(env, _success, NULL);
-    jint retval = get_band_min_max(token, dataset, attempts, band, approx_okay, minmax, success);
+    jint retval = get_band_min_max(token, dataset, attempts, band, approx_okay, minmax, (int *)success);
     (*env)->ReleaseIntArrayElements(env, _success, success, 0);
     (*env)->ReleaseDoubleArrayElements(env, _minmax, minmax, 0);
 

--- a/src/experiments/thread/Makefile
+++ b/src/experiments/thread/Makefile
@@ -5,7 +5,7 @@ LDFLAGS ?= $(shell pkg-config gdal --libs) -L$(shell pwd) -lgdalwarp_bindings -l
 BOOST_ROOT ?= /usr/include
 SO ?= so
 
-all: rawthread wrapthread pattern
+all: rawthread wrapthread pattern oversubscribe
 
 ../../libgdalwarp_bindings.$(SO):
 	make -C ../.. libgdalwarp_bindings.$(SO)
@@ -20,6 +20,9 @@ wrapthread: wrapthread.o libgdalwarp_bindings.$(SO)
 	$(CC) $< $(LDFLAGS) -o $@
 
 pattern: pattern.o libgdalwarp_bindings.$(SO)
+	$(CC) $< $(LDFLAGS) -o $@
+
+oversubscribe: oversubscribe.o libgdalwarp_bindings.$(SO)
 	$(CC) $< $(LDFLAGS) -o $@
 
 %.o: %.cpp

--- a/src/experiments/thread/oversubscribe.cpp
+++ b/src/experiments/thread/oversubscribe.cpp
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2019 Azavea
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cassert>
+#include <cstdio>
+#include <cstdlib>
+#include <cstdint>
+#include <random>
+
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <pthread.h>
+
+#include "../../bindings.h"
+#include "../../locked_dataset.hpp"
+
+// Strings
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wwrite-strings"
+const char *xres = "5";
+const char *yres = "7";
+char const *bad_uri = "HOPEFULLY_THERE_IS_NO_FILE_WITH_THIS_NAME";
+char const *good_uris[] = {
+    "/tmp/A.tif", "/tmp/B.tif", "/tmp/C.tif",
+    "/tmp/D.tif", "/tmp/E.tif", "/tmp/F.tif",
+    "/tmp/G.tif", "/tmp/H.tif", "/tmp/I.tif"};
+char const *options[] = {
+    "-tap", "-tr", xres, yres,
+    "-r", "bilinear",
+    "-t_srs", "epsg:3857",
+    nullptr};
+#pragma GCC diagnostic pop
+
+// Constants
+constexpr int N = (1024);
+constexpr int DIM = 1 << 8;
+constexpr int BUFFERSIZE = DIM * DIM;
+constexpr int ATTEMPTS = 1 << 20;
+
+// Threads
+int lg_steps = 12;
+pthread_t threads[N];
+
+// ANSI
+// Reference: https://stackoverflow.com/questions/3219393/stdlib-and-colored-output-in-c
+// Reference: https://en.wikipedia.org/wiki/ANSI_escape_code#Colors
+#define ANSI_COLOR_RED "\x1b[31;1m"
+#define ANSI_COLOR_GREEN "\x1b[32;1m"
+#define ANSI_COLOR_YELLOW "\x1b[33;1m"
+#define ANSI_COLOR_BLUE "\x1b[34;1m"
+#define ANSI_COLOR_MAGENTA "\x1b[35;1m"
+#define ANSI_COLOR_CYAN "\x1b[36;1m"
+#define ANSI_COLOR_RESET "\x1b[0m"
+
+void *reader(void *argv1)
+{
+    auto g = std::mt19937(std::random_device{}());
+    auto dist = std::uniform_int_distribution<int>(0, 999);
+    char *buf = static_cast<char *>(malloc(BUFFERSIZE));
+    double transform[6];
+    int scratch1, scratch2;
+    int src_window[4] = {0, 0, DIM, DIM};
+    int dst_window[2] = {DIM, DIM};
+
+    for (int k = 0; k < (1 << lg_steps); ++k)
+    {
+        uint64_t token;
+        const char *uri = good_uris[dist(g) % 9];
+
+        token = get_token(uri, options);
+
+        get_crs_wkt(token, token % 2, ATTEMPTS, buf, BUFFERSIZE);
+        get_crs_proj4(token, token % 2, ATTEMPTS, buf, BUFFERSIZE);
+        get_band_nodata(token, token % 2, ATTEMPTS, 1, transform, &scratch1);
+        get_width_height(token, token % 2, ATTEMPTS, &scratch1, &scratch2);
+        get_data(token, token % 2, ATTEMPTS, src_window, dst_window, 1, 1 /* GDT_Byte */, buf);
+    }
+
+    return nullptr;
+}
+
+bool keep_going = true;
+
+int main(int argc, char **argv)
+{
+    int n = N;
+
+    if (argc < 2)
+    {
+        exit(-1);
+    }
+    if (argc >= 3)
+    {
+        sscanf(argv[2], "%d", &lg_steps);
+        fprintf(stderr, ANSI_COLOR_BLUE "lg_steps = %d\n" ANSI_COLOR_RESET, lg_steps);
+    }
+    if (argc >= 4)
+    {
+        sscanf(argv[3], "%d", &n);
+        if (n > N || n < 0)
+        {
+            n = N;
+        }
+        fprintf(stderr, ANSI_COLOR_BLUE "n = %d\n" ANSI_COLOR_RESET, n);
+    }
+
+    // Setup
+
+    init(1 << 2);
+    dup2(open("/dev/null", O_WRONLY), 2);
+
+    for (int i = 0; i < n; ++i)
+    {
+        assert(pthread_create(&threads[i], nullptr, reader, argv[1]) == 0);
+    }
+    for (int i = 0; i < n; ++i)
+    {
+        assert(pthread_join(threads[i], nullptr) == 0);
+        fprintf(stdout, ANSI_COLOR_MAGENTA "." ANSI_COLOR_RESET);
+    }
+    fprintf(stdout, "\n");
+
+    deinit();
+
+    return 0;
+}

--- a/src/flat_lru_cache.hpp
+++ b/src/flat_lru_cache.hpp
@@ -266,7 +266,6 @@ class flat_lru_cache
             {
                 m_tags[best_index] = tag;
                 m_atimes[best_index] = ++m_time;
-                m_values[best_index].prepare_for_overwrite(); // Helgrind and DRD
                 m_values[best_index] = std::move(ds);
                 m_size++;
                 return &(m_values[best_index]);

--- a/src/flat_lru_cache.hpp
+++ b/src/flat_lru_cache.hpp
@@ -89,6 +89,7 @@ class flat_lru_cache
         {
             m_tags[i] = 0;
             m_atimes[i] = 0;
+            m_values[i].lock_for_deletion();
             m_values[i] = locked_dataset();
             m_size = 0;
         }

--- a/src/locked_dataset.hpp
+++ b/src/locked_dataset.hpp
@@ -61,17 +61,7 @@ class locked_dataset
         open();
     }
 
-    locked_dataset(const locked_dataset &rhs)
-        : m_datasets{nullptr, nullptr},
-          m_uri_options(rhs.m_uri_options),
-          m_dataset_lock(PTHREAD_MUTEX_INITIALIZER),
-          m_use_count(static_cast<int>(rhs.m_use_count))
-    {
-#ifdef DEBUG
-        fprintf(stderr, "COPY CONSTRUCTOR\n");
-#endif
-        open();
-    }
+    locked_dataset(locked_dataset &rhs) = delete;
 
     locked_dataset(locked_dataset &&rhs) noexcept
         : m_uri_options(std::exchange(rhs.m_uri_options, uri_options_t())),
@@ -85,15 +75,7 @@ class locked_dataset
         m_datasets[WARPED] = std::exchange(rhs.m_datasets[WARPED], nullptr);
     }
 
-    locked_dataset &operator=(const locked_dataset &rhs)
-    {
-        close();
-        *this = locked_dataset(rhs.m_uri_options);
-#ifdef DEBUG
-        fprintf(stderr, "ASSIGNMENT OPERATOR\n");
-#endif
-        return *this;
-    }
+    locked_dataset &operator=(locked_dataset &rhs) = delete;
 
     locked_dataset &operator=(locked_dataset &&rhs) noexcept
     {

--- a/src/locked_dataset.hpp
+++ b/src/locked_dataset.hpp
@@ -87,7 +87,6 @@ class locked_dataset
         m_datasets[SOURCE] = std::exchange(rhs.m_datasets[SOURCE], nullptr);
         m_datasets[WARPED] = std::exchange(rhs.m_datasets[WARPED], nullptr);
         m_uri_options = std::move(rhs.m_uri_options);
-        //m_use_count = 0; // m_use_count already known to be zero, rhs.m_use_count also zero
         pthread_mutex_unlock(&m_dataset_lock); // m_dataset_lock known to be locked prior to this call
 
         return *this;

--- a/src/unit_tests/cache_tests.cpp
+++ b/src/unit_tests/cache_tests.cpp
@@ -67,9 +67,15 @@ BOOST_AUTO_TEST_CASE(get_same_test)
 {
     auto cache = flat_lru_cache(4);
     BOOST_TEST(cache.size() == 0);
-    cache.get(uri_options1);
+    for (auto ld : cache.get(uri_options1))
+    {
+        ld->dec();
+    }
     BOOST_TEST(cache.size() == 1);
-    cache.get(uri_options1);
+    for (auto ld : cache.get(uri_options1))
+    {
+        ld->dec();
+    }
     BOOST_TEST(cache.size() == 1);
     cache.clear();
     BOOST_TEST(cache.size() == 0);
@@ -79,9 +85,15 @@ BOOST_AUTO_TEST_CASE(get_different_test)
 {
     auto cache = flat_lru_cache(4);
     BOOST_TEST(cache.size() == 0);
-    cache.get(uri_options1);
+    for (auto ld : cache.get(uri_options1))
+    {
+        ld->dec();
+    }
     BOOST_TEST(cache.size() == 1);
-    cache.get(uri_options2);
+    for (auto ld : cache.get(uri_options2))
+    {
+        ld->dec();
+    }
     BOOST_TEST(cache.size() == 2);
     cache.clear();
     BOOST_TEST(cache.size() == 0);

--- a/src/unit_tests/dataset_tests.cpp
+++ b/src/unit_tests/dataset_tests.cpp
@@ -178,32 +178,12 @@ BOOST_AUTO_TEST_CASE(get_pixels_test)
     BOOST_TEST(actual == expected);
 }
 
-BOOST_AUTO_TEST_CASE(copy_constructor_test)
-{
-    auto ld1 = locked_dataset(uri_options1);
-    auto ld2 = locked_dataset(ld1);
-
-    BOOST_TEST(ld1.valid() == true);
-    BOOST_TEST(ld2.valid() == true);
-}
-
 BOOST_AUTO_TEST_CASE(move_constructor_test)
 {
     auto ld1 = locked_dataset(uri_options1);
     auto ld2 = locked_dataset(std::move(ld1));
 
     BOOST_TEST(ld1.valid() == false);
-    BOOST_TEST(ld2.valid() == true);
-}
-
-BOOST_AUTO_TEST_CASE(assignment_test)
-{
-    auto ld1 = locked_dataset(uri_options1);
-    auto ld2 = locked_dataset();
-
-    ld2 = ld1;
-
-    BOOST_TEST(ld1.valid() == true);
     BOOST_TEST(ld2.valid() == true);
 }
 


### PR DESCRIPTION
This branch appears to be clean, as all errors reported by Helgrind are from GDAL during a single-threaded initialization, or of the form
```
==6514== Locks held: none
==6514==    at 0x4E753CB: store (atomic_base.h:374)
==6514==    by 0x4E753CB: std::__atomic_base<unsigned long>::operator=(unsigned long) (atomic_base.h:267)
==6514==    by 0x4E746F8: flat_lru_cache::get(std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > > const&, int) (flat_lru_cache.hpp:182)
==6514==    by 0x4E7158F: get_crs_wkt (bindings.cpp:213)
==6514==    by 0x109955: reader(void*) (oversubscribe.cpp:86)
==6514==    by 0x4C3683E: mythread_wrapper (hg_intercepts.c:389)
==6514==    by 0x50AC6DA: start_thread (pthread_create.c:463)
==6514==    by 0x55FD88E: clone (clone.S:95)
```
or
```
==6514== Possible data race during write of size 4 at 0xEC30264 by thread #3
==6514== Locks held: 3, at addresses 0xD691590 0xD691730 0xE9C3448
==6514==    at 0xEA070BA: pj_inv (pj_inv.c:17)
==6514==    by 0xEA0F589: pj_transform (pj_transform.c:225)
==6514==    by 0x5D0AED4: OGRProj4CT::TransformEx(int, double*, double*, double*, int*) (ogrct.cpp:1305)
==6514==    by 0x5DC8CCD: GDALGenImgProjTransform (gdaltransformer.cpp:2035)
==6514==    by 0x5DCC94F: GDALSuggestedWarpOutput2 (gdaltransformer.cpp:457)
==6514==    by 0x5E15CE6: GDALWarpCreateOutput(int, void**, char const*, char const*, char**, char***, GDALDataType, void**, bool, GDALWarpAppOptions*) (gdalwarp_lib.cpp:2477)
==6514==    by 0x5E1935F: GDALWarp (gdalwarp_lib.cpp:1010)
==6514==    by 0x4E740DA: locked_dataset::open() (locked_dataset.hpp:475)
==6514==    by 0x4E734CB: locked_dataset::locked_dataset(std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > > const&) (locked_dataset.hpp:58)
==6514==    by 0x4E74A76: flat_lru_cache::insert(unsigned long, std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > > const&) (flat_lru_cache.hpp:263)
==6514==    by 0x4E7479F: flat_lru_cache::get(std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > > const&, int) (flat_lru_cache.hpp:197)
==6514==    by 0x4E7158F: get_crs_wkt (bindings.cpp:213)
```
but the latter may indicate that only one call to `GDALWarp` may be in flight at once (if it is actually a problem).