### PR TITLE
Destroy Objects Before They Are Destroyed

### DIFF
--- a/src/bindings.cpp
+++ b/src/bindings.cpp
@@ -157,7 +157,15 @@ void deinit()
         delete cache;
         cache = nullptr;
     }
+
     token_deinit();
+}
+
+void __attribute__((destructor)) fini(void)
+{
+    deinit();
+    GDALDestroy();
+    usleep(680000); // nearly an eternity
 }
 
 /**
@@ -176,7 +184,7 @@ void deinit()
  * @return True iff the operation succeeded
  */
 int get_block_size(uint64_t token, int dataset, int attempts, int copies,
-               int band_number, int * width, int * height)
+                   int band_number, int *width, int *height)
 {
     DOIT(get_block_size(dataset, band_number, width, height));
 }


### PR DESCRIPTION
Because this library is (at time of writing) statically linked to `libstdc++`, when the JVM quits, some destruction code gets run twice:  once because `libstdc++` has just been unloaded then again presumably  as part of an `atexit` action.  This was causing some C++ objects to get destroyed while they were being destroyed resulting in this error:

```
pure virtual method called
terminate called without an active exception
```

Closes: https://github.com/geotrellis/gdal-warp-bindings/issues/37