### PR TITLE
Add Optional In-Built ThreadLocal Arrays for Metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ src/experiments/thread/rawthread
 src/experiments/thread/wrapthread
 src/experiments/thread/pattern
 src/experiments/thread/oversubscribe
+src/experiments/thread/metadata
 src/unit_tests/dataset_tests
 src/unit_tests/token_tests
 src/unit_tests/cache_tests

--- a/src/bindings.cpp
+++ b/src/bindings.cpp
@@ -118,7 +118,7 @@ inline void pthread_yield()
 #define DOIT(fn)                                                                          \
     bool done = false;                                                                    \
     auto query_result = query_token(token);                                               \
-    int code = -CPLE_AppDefined;                                                          \
+    int code = CPLE_None;                                                                 \
     uint64_t then, now;                                                                   \
     if (query_result)                                                                     \
     {                                                                                     \

--- a/src/experiments/thread/Makefile
+++ b/src/experiments/thread/Makefile
@@ -5,7 +5,7 @@ LDFLAGS ?= $(shell pkg-config gdal --libs) -L$(shell pwd) -lgdalwarp_bindings -l
 BOOST_ROOT ?= /usr/include
 SO ?= so
 
-all: rawthread wrapthread pattern oversubscribe
+all: rawthread wrapthread pattern oversubscribe metadata
 
 ../../libgdalwarp_bindings.$(SO):
 	$(MAKE) -C ../.. libgdalwarp_bindings.$(SO)
@@ -25,6 +25,9 @@ pattern: pattern.o libgdalwarp_bindings.$(SO)
 oversubscribe: oversubscribe.o libgdalwarp_bindings.$(SO)
 	$(CC) $< $(LDFLAGS) -o $@
 
+metadata: metadata.o libgdalwarp_bindings.$(SO)
+	$(CC) $< $(LDFLAGS) -lboost_timer -o $@
+
 %.o: %.cpp
 	$(CXX) $(CFLAGS) $(CXXFLAGS) $(GDALCFLAGS) -I$(BOOST_ROOT) $< -c -o $@
 
@@ -32,6 +35,6 @@ clean:
 	rm -f *.o  libgdalwarp_bindings.$(SO)
 
 cleaner: clean
-	rm -f rawthread wrapthread pattern oversubscribe
+	rm -f rawthread wrapthread pattern oversubscribe metadata
 
 cleanest: cleaner

--- a/src/experiments/thread/metadata.cpp
+++ b/src/experiments/thread/metadata.cpp
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2019 Azavea
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cstdint>
+#include <cstdlib>
+#include <cassert>
+
+#include <boost/timer/timer.hpp>
+
+#include <gdal.h>
+
+#include "../../bindings.h"
+#include "../../locked_dataset.hpp"
+
+char const *options[] = {
+    "-dstnodata", "107",
+    "-tap", "-tr", "33", "42",
+    "-r", "bilinear",
+    "-t_srs", "epsg:3857",
+    "-co", "BLOCKXSIZE=512", "-co", "BLOCKYSIZE=512",
+    nullptr};
+
+namespace t = boost::timer;
+
+void CSLDestroy(char **papszStrList)
+{
+  if (!papszStrList)
+    return;
+
+  for (char **papszPtr = papszStrList; *papszPtr != nullptr; ++papszPtr)
+  {
+    free(*papszPtr);
+  }
+
+  free(papszStrList);
+}
+
+int main(int argc, char **argv)
+{
+  init(33);
+
+  uint64_t token = get_token(argv[1], options);
+  auto handle = GDALOpen(argv[1], GA_ReadOnly);
+
+  char **domain_list = NULL;
+
+  {
+    t::auto_cpu_timer timer;
+
+    for (int i = 0; i < (1 << 18); ++i)
+    {
+      assert(noop(token, locked_dataset::SOURCE, 0, 1) > 0);
+    }
+  }
+
+  {
+    t::auto_cpu_timer timer;
+
+    for (int i = 0; i < (1 << 18); ++i)
+    {
+      assert(get_metadata_domain_list(token, 0, 10, 1, 0, &domain_list) > 0);
+      CSLDestroy(domain_list);
+    }
+  }
+  {
+    t::auto_cpu_timer timer;
+
+    for (int i = 0; i < (1 << 18); ++i)
+    {
+      domain_list = GDALGetMetadataDomainList(handle);
+      CSLDestroy(domain_list);
+    }
+  }
+
+  GDALClose(handle);
+  deinit();
+}

--- a/src/main/GDALWarpMetadataTest.java
+++ b/src/main/GDALWarpMetadataTest.java
@@ -1,0 +1,58 @@
+
+/*
+ * Copyright 2019 Azavea
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import com.azavea.gdal.GDALWarp;
+import java.util.Arrays;
+import java.util.Random;
+
+class GDALWarpMetadataTest {
+
+    private static String options[] = { /* */
+            "-tap", "-tr", "5", "7", /* */
+            "-r", "bilinear", /* */
+            "-t_srs", "epsg:3857", /* */
+            "-co", "BLOCKXSIZE=512", "-co", "BLOCKYSIZE=512" /* */
+    };
+
+    public static void main(String[] args) throws Exception {
+        long token = GDALWarp.get_token(args[0], options);
+        long before, after;
+        int len = 0;
+        //byte[][] domain_list1 = new byte[1 << 10][1 << 10];
+
+        // Domain List Metadata
+        before = System.currentTimeMillis();
+        for (int j = 0; j < (1 << 18); ++j) {
+            byte[][] domain_list1 = new byte[1 << 4][1 << 10];
+            GDALWarp.get_metadata_domain_list(token, GDALWarp.SOURCE, 0, 0, domain_list1);
+            for (int i = 0; i < domain_list1.length; ++i) {
+                String str = new String(domain_list1[i], "UTF-8").trim();
+                if (str.length() > 0) {
+                    len = len + str.length();
+                } else {
+                    break;
+                }
+            }
+        }
+        after = System.currentTimeMillis();
+        System.out.println(after - before);
+
+
+        GDALWarp.deinit();
+        return;
+    }
+}

--- a/src/main/GDALWarpMetadataTest.java
+++ b/src/main/GDALWarpMetadataTest.java
@@ -32,25 +32,92 @@ class GDALWarpMetadataTest {
         long token = GDALWarp.get_token(args[0], options);
         long before, after;
         int len = 0;
-        //byte[][] domain_list1 = new byte[1 << 10][1 << 10];
 
-        // Domain List Metadata
-        before = System.currentTimeMillis();
-        for (int j = 0; j < (1 << 18); ++j) {
-            byte[][] domain_list1 = new byte[1 << 4][1 << 10];
-            GDALWarp.get_metadata_domain_list(token, GDALWarp.SOURCE, 0, 0, domain_list1);
-            for (int i = 0; i < domain_list1.length; ++i) {
-                String str = new String(domain_list1[i], "UTF-8").trim();
-                if (str.length() > 0) {
-                    len = len + str.length();
-                } else {
-                    break;
+        // Noop
+        {
+            len = 0;
+            before = System.currentTimeMillis();
+            for (int j = 0; j < (1 << 18); ++j) {
+                len += GDALWarp.noop(token, GDALWarp.SOURCE, 0);
+            }
+            after = System.currentTimeMillis();
+            System.out.println(after - before + " " + len);
+        }
+
+        // Domain List Metadata ThreadLocal
+        {
+            len = 0;
+            before = System.currentTimeMillis();
+            String[][] domain_list = new String[1][0];
+            for (int j = 0; j < (1 << 18); ++j) {
+                GDALWarp.get_metadata_domain_list(token, GDALWarp.SOURCE, 0, 0, domain_list);
+                for (int i = 0; i < domain_list[0].length; ++i) {
+                    len = len + domain_list[0][i].length();
                 }
             }
+            after = System.currentTimeMillis();
+            System.out.println(after - before + " " + len);
         }
-        after = System.currentTimeMillis();
-        System.out.println(after - before);
 
+        // Domain List Metadata Reallocate 16⨯1024
+        {
+            // Domain List Metadata
+            before = System.currentTimeMillis();
+            for (int j = 0; j < (1 << 18); ++j) {
+                byte[][] domain_list1 = new byte[1 << 4][1 << 10];
+                GDALWarp.get_metadata_domain_list(token, GDALWarp.SOURCE, 0, 0, domain_list1);
+                for (int i = 0; i < domain_list1.length; ++i) {
+                    String str = new String(domain_list1[i], "UTF-8").trim();
+                    if (str.length() > 0) {
+                        len = len + str.length();
+                    } else {
+                        break;
+                    }
+                }
+            }
+            after = System.currentTimeMillis();
+            System.out.println(after - before + " " + len);
+        }
+
+        // Domain List Metadata Reallocate 1024⨯1024
+        {
+            // Domain List Metadata
+            before = System.currentTimeMillis();
+            for (int j = 0; j < (1 << 18); ++j) {
+                byte[][] domain_list1 = new byte[1 << 10][1 << 10];
+                GDALWarp.get_metadata_domain_list(token, GDALWarp.SOURCE, 0, 0, domain_list1);
+                for (int i = 0; i < domain_list1.length; ++i) {
+                    String str = new String(domain_list1[i], "UTF-8").trim();
+                    if (str.length() > 0) {
+                        len = len + str.length();
+                    } else {
+                        break;
+                    }
+                }
+            }
+            after = System.currentTimeMillis();
+            System.out.println(after - before + " " + len);
+        }
+
+        // Domain List Metadata Preallocate
+        {
+            // Domain List Metadata
+            byte[][] domain_list1 = new byte[1 << 10][1 << 10];
+            before = System.currentTimeMillis();
+            for (int j = 0; j < (1 << 18); ++j) {
+                GDALWarp.get_metadata_domain_list(token, GDALWarp.SOURCE, 0, 0, domain_list1);
+                for (int i = 0; i < domain_list1.length; ++i) {
+                    String str = new String(domain_list1[i], "UTF-8").trim();
+                    if (str.length() > 0) {
+                        len = len + str.length();
+                    } else {
+                        break;
+                    }
+                }
+            }
+            after = System.currentTimeMillis();
+            System.out.println(after - before + " " + len);
+        }
 
         GDALWarp.deinit();
         return;

--- a/src/main/GDALWarpThreadTest.java
+++ b/src/main/GDALWarpThreadTest.java
@@ -268,61 +268,60 @@ class GDALWarpThreadTest extends Thread {
 
         // Domain List Metadata
         {
-            byte[][] domain_list1 = new byte[1 << 10][1 << 10];
+            String[][] domain_list1 = new String[1][0];
             System.out.println(ANSI_BLUE + "Source domain list:" + ANSI_RESET);
             GDALWarp.get_metadata_domain_list(token, GDALWarp.SOURCE, 0, 0, domain_list1);
-            for (int i = 0; i < domain_list1.length; ++i) {
-                String str = new String(domain_list1[i], "UTF-8").trim();
-                if (str.length() > 0) {
-                    System.out.println(ANSI_GREEN + str + ANSI_RESET);
+            for (int i = 0; i < domain_list1[0].length; ++i) {
+                if (domain_list1[0][i].length() > 0) {
+                    System.out.println(ANSI_GREEN + domain_list1[0][i] + ANSI_RESET);
                 }
             }
-
-            byte[][] domain_list2 = new byte[1 << 10][1 << 10];
+        }
+        {
+            String[][] domain_list2 = new String[1][0];
             System.out.println(ANSI_BLUE + "Warped domain list:" + ANSI_RESET);
             GDALWarp.get_metadata_domain_list(token, GDALWarp.WARPED, 0, 0, domain_list2);
-            for (int i = 0; i < domain_list2.length; ++i) {
-                String str = new String(domain_list2[i], "UTF-8").trim();
-                if (str.length() > 0) {
-                    System.out.println(ANSI_GREEN + str + ANSI_RESET);
+            for (int i = 0; i < domain_list2[0].length; ++i) {
+                if (domain_list2[0][i].length() > 0) {
+                    System.out.println(ANSI_GREEN + domain_list2[0][i] + ANSI_RESET);
                 }
             }
         }
 
         // Metadata
         {
-            byte[][] list1 = new byte[1 << 10][1 << 10];
+            String[][] list1 = new String[1][0];
             System.out.println(ANSI_BLUE + "Source metadata:" + ANSI_RESET);
             GDALWarp.get_metadata(token, GDALWarp.SOURCE, 0, 0, "", list1);
-            for (int i = 0; i < list1.length; ++i) {
-                String str = new String(list1[i], "UTF-8").trim();
-                if (str.length() > 0) {
-                    System.out.println(ANSI_GREEN + str + ANSI_RESET);
+            for (int i = 0; i < list1[0].length; ++i) {
+                if (list1[0][i].length() > 0) {
+                    System.out.println(ANSI_GREEN + list1[0][i] + ANSI_RESET);
                 }
             }
-
-            byte[][] list2 = new byte[1 << 10][1 << 10];
+        }
+        {
+            String[][] list2 = new String[1][0];
             System.out.println(ANSI_BLUE + "Warped metadata:" + ANSI_RESET);
             GDALWarp.get_metadata(token, GDALWarp.WARPED, 0, 0, "", list2);
-            for (int i = 0; i < list2.length; ++i) {
-                String str = new String(list2[i], "UTF-8").trim();
-                if (str.length() > 0) {
-                    System.out.println(ANSI_GREEN + str + ANSI_RESET);
+            for (int i = 0; i < list2[0].length; ++i) {
+                if (list2[0][i].length() > 0) {
+                    System.out.println(ANSI_GREEN + list2[0][i] + ANSI_RESET);
                 }
             }
         }
 
         // Metadata item
         {
-            byte[] bytes1 = new byte[1 << 10];
+            String[] item = new String[1];
             System.out.print(ANSI_BLUE + "Source AREA_OR_POINT:" + ANSI_RESET);
-            GDALWarp.get_metadata_item(token, GDALWarp.SOURCE, 0, 0, "AREA_OR_POINT", "", bytes1);
-            System.out.println(ANSI_GREEN + new String(bytes1, "UTF-8").trim() + ANSI_RESET);
-
-            byte[] bytes2 = new byte[1 << 10];
+            GDALWarp.get_metadata_item(token, GDALWarp.SOURCE, 0, 0, "AREA_OR_POINT", "", item);
+            System.out.println(ANSI_GREEN + item[0] + ANSI_RESET);
+        }
+        {
+            String[] item = new String[1];
             System.out.print(ANSI_BLUE + "Warped AREA_OR_POINT:" + ANSI_RESET);
-            GDALWarp.get_metadata_item(token, GDALWarp.WARPED, 0, 0, "AREA_OR_POINT", "", bytes2);
-            System.out.println(ANSI_GREEN + new String(bytes1, "UTF-8").trim() + ANSI_RESET);
+            GDALWarp.get_metadata_item(token, GDALWarp.WARPED, 0, 0, "AREA_OR_POINT", "", item);
+            System.out.println(ANSI_GREEN + item[0] + ANSI_RESET);
         }
 
         // Overviews

--- a/src/main/Makefile
+++ b/src/main/Makefile
@@ -19,6 +19,9 @@ java/com/azavea/gdal/GDALWarp.class java/cz/adamh/utils/NativeUtils.class: java/
 GDALWarpThreadTest.class: GDALWarpThreadTest.java gdalwarp.jar
 	$(JAVAC) -cp gdalwarp.jar $<
 
+GDALWarpMetadataTest.class: GDALWarpMetadataTest.java gdalwarp.jar
+	$(JAVAC) -cp gdalwarp.jar $<
+
 # MIT-Licensed code (that license is compatible with Apache 2.0)
 java/cz/adamh/utils/NativeUtils.java:
 	wget -k "https://raw.githubusercontent.com/adamheinrich/native-utils/e6a39489662846a77504634b6fafa4995ede3b1d/src/main/$@" -O $@


### PR DESCRIPTION
Adds
   - `get_metadata_domain_list(long token, int dataset, int attempts, int band_number, String[][] domain_list)`
   - `int get_metadata(long token, int dataset, int attempts, int band_number, String domain, String[][] list)`
   - `int get_metadata_item(long token, int dataset, int attempts, int band_number, String key, String domain, String[] value)`

A string array of the form `String[1][0]` should be passed as the last argument to the first one.  When the call returns, the array will be of the form `String[1][n]` with the n domain list items stored within.  Similarly for the second one.  The third one should be passed a String array of the form `String[1]`, upon return it will contain the metadata item.

Depends on https://github.com/geotrellis/gdal-warp-bindings/pull/58
Closes https://github.com/geotrellis/gdal-warp-bindings/issues/54