### PR TITLE
Add GetHistogram binding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,9 @@
+*.aux.xml
+*.dll
+*.dylib
 *.o
 *.obj
 *.so
-*.dylib
-*.dll
 *.tif
 *.vrt
 .vscode/launch.json

--- a/src/bindings.cpp
+++ b/src/bindings.cpp
@@ -336,19 +336,20 @@ int get_block_size(uint64_t token, int dataset, int attempts, int copies,
  * @param attempts The number of attempts to make before giving up
  * @param copies The desired number of datasets
  * @param band_number The band in question
- * @param dfMin the lower bound of the histogram
- * @param dfMax the upper bound of the histogram
- * @param panHistogram array into which the histogram totals are placed
- * @param bIncludeOutOfRange Whether to map out of range values into the first/last buckets
- * @param bApproxOK Whether to accept an approximate histogram. With COGs, will cause the use of overviews
+ * @param lower the lower bound of the histogram
+ * @param upper the upper bound of the histogram
+ * @param num_buckets The number of histogram buckts
+ * @param hist array into which the histogram totals are placed
+ * @param include_out_of_range Whether to map out of range values into the first/last buckets
+ * @param approx_ok Whether to accept an approximate histogram. With COGs, will cause the use of overviews
  */
 int get_histogram(uint64_t token, int dataset, int attempts, int copies,
-                  int band_number, double dfMin, double dfMax, int nBuckets,
-                  GUIntBig *panHistogram, int bIncludeOutOfRange, int bApproxOK)
+                  int band_number, double lower, double upper, int num_buckets,
+                  GUIntBig *hist, int include_out_of_range, int approx_ok)
 {
     uint64_t nanos = default_nanos;
     DOIT(get_histogram(dataset, band_number,
-                       dfMin, dfMax, nBuckets, panHistogram, bIncludeOutOfRange, bApproxOK));
+                       lower, upper, num_buckets, hist, include_out_of_range, approx_ok));
 }
 
 /**

--- a/src/bindings.cpp
+++ b/src/bindings.cpp
@@ -327,6 +327,18 @@ int get_block_size(uint64_t token, int dataset, int attempts, int copies,
     DOIT(get_block_size(dataset, band_number, width, height));
 }
 
+/** Get the histogram of the given band
+ */
+int get_histogram(uint64_t token, int dataset, int attempts, int copies,
+		  int band_number,
+		  double dfMin, double dfMax,
+		  int nBuckets, GUIntBig *panHistogram, int bIncludeOutOfRange, int bApproxOK)
+{
+    uint64_t nanos = default_nanos;
+    DOIT(get_histogram(dataset, band_number,
+		       dfMin, dfMax, nBuckets, panHistogram, bIncludeOutOfRange, bApproxOK));
+}
+
 /**
  * Get the offset of the given band.
  *

--- a/src/bindings.cpp
+++ b/src/bindings.cpp
@@ -343,12 +343,12 @@ int get_block_size(uint64_t token, int dataset, int attempts, int copies,
  * @param bApproxOK Whether to accept an approximate histogram. With COGs, will cause the use of overviews
  */
 int get_histogram(uint64_t token, int dataset, int attempts, int copies,
-                  int band_number,
-                  double dfMin, double dfMax, GUIntBig *panHistogram, int bIncludeOutOfRange, int bApproxOK)
+                  int band_number, double dfMin, double dfMax, int nBuckets,
+                  GUIntBig *panHistogram, int bIncludeOutOfRange, int bApproxOK)
 {
     uint64_t nanos = default_nanos;
     DOIT(get_histogram(dataset, band_number,
-                       dfMin, dfMax, panHistogram, bIncludeOutOfRange, bApproxOK));
+                       dfMin, dfMax, nBuckets, panHistogram, bIncludeOutOfRange, bApproxOK));
 }
 
 /**

--- a/src/bindings.cpp
+++ b/src/bindings.cpp
@@ -330,13 +330,12 @@ int get_block_size(uint64_t token, int dataset, int attempts, int copies,
 /** Get the histogram of the given band
  */
 int get_histogram(uint64_t token, int dataset, int attempts, int copies,
-		  int band_number,
-		  double dfMin, double dfMax,
-		  int nBuckets, GUIntBig *panHistogram, int bIncludeOutOfRange, int bApproxOK)
+                  int band_number,
+                  double dfMin, double dfMax, GUIntBig *panHistogram, int bIncludeOutOfRange, int bApproxOK)
 {
     uint64_t nanos = default_nanos;
     DOIT(get_histogram(dataset, band_number,
-		       dfMin, dfMax, nBuckets, panHistogram, bIncludeOutOfRange, bApproxOK));
+                       dfMin, dfMax, panHistogram, bIncludeOutOfRange, bApproxOK));
 }
 
 /**

--- a/src/bindings.cpp
+++ b/src/bindings.cpp
@@ -327,7 +327,20 @@ int get_block_size(uint64_t token, int dataset, int attempts, int copies,
     DOIT(get_block_size(dataset, band_number, width, height));
 }
 
-/** Get the histogram of the given band
+/** Get the histogram of a given band
+ *
+ * @param token A token associated with some uri ⨯ options pair
+ * @param dataset 0 (or locked_dataset::SOURCE) for the source
+ *                dataset, 1 (or locked_dataset::WARPED) for the
+ *                warped dataset
+ * @param attempts The number of attempts to make before giving up
+ * @param copies The desired number of datasets
+ * @param band_number The band in question
+ * @param dfMin the lower bound of the histogram
+ * @param dfMax the upper bound of the histogram
+ * @param panHistogram array into which the histogram totals are placed
+ * @param bIncludeOutOfRange Whether to map out of range values into the first/last buckets
+ * @param bApproxOK Whether to accept an approximate histogram. With COGs, will cause the use of overviews
  */
 int get_histogram(uint64_t token, int dataset, int attempts, int copies,
                   int band_number,

--- a/src/bindings.h
+++ b/src/bindings.h
@@ -34,9 +34,9 @@ extern "C"
 
     int get_histogram(uint64_t token, int dataset, int attempts, int copies,
                       int band_number,
-                      double dfMin, double dfMax, int nBuckets,
-                      unsigned long long int *panHistogram,
-                      int bIncludeOutOfRange, int bApproxOK);
+                      double lower, double upper, int num_buckets,
+                      unsigned long long int *hist,
+                      int include_out_of_range, int approx_ok);
 
     int get_offset(uint64_t token, int dataset, int attempts, int copies,
                    int band_number, double *offset, int *success);

--- a/src/bindings.h
+++ b/src/bindings.h
@@ -33,10 +33,10 @@ extern "C"
                        int band_number, int *width, int *height);
 
     int get_histogram(uint64_t token, int dataset, int attempts, int copies,
-		      int band_number,
-		      double dfMin, double dfMax,
-		      int nBuckets, unsigned long long int *panHistogram,
-		      int bIncludeOutOfRange, int bApproxOK);
+                      int band_number,
+                      double dfMin, double dfMax,
+                      unsigned long long int *panHistogram,
+                      int bIncludeOutOfRange, int bApproxOK);
 
     int get_offset(uint64_t token, int dataset, int attempts, int copies,
                    int band_number, double *offset, int *success);

--- a/src/bindings.h
+++ b/src/bindings.h
@@ -32,6 +32,12 @@ extern "C"
     int get_block_size(uint64_t token, int dataset, int attempts, int copies,
                        int band_number, int *width, int *height);
 
+    int get_histogram(uint64_t token, int dataset, int attempts, int copies,
+		      int band_number,
+		      double dfMin, double dfMax,
+		      int nBuckets, unsigned long long int *panHistogram,
+		      int bIncludeOutOfRange, int bApproxOK);
+
     int get_offset(uint64_t token, int dataset, int attempts, int copies,
                    int band_number, double *offset, int *success);
 

--- a/src/bindings.h
+++ b/src/bindings.h
@@ -34,7 +34,7 @@ extern "C"
 
     int get_histogram(uint64_t token, int dataset, int attempts, int copies,
                       int band_number,
-                      double dfMin, double dfMax,
+                      double dfMin, double dfMax, int nBuckets,
                       unsigned long long int *panHistogram,
                       int bIncludeOutOfRange, int bApproxOK);
 

--- a/src/com_azavea_gdal_GDALWarp.c
+++ b/src/com_azavea_gdal_GDALWarp.c
@@ -133,16 +133,16 @@ JNIEXPORT jint JNICALL Java_com_azavea_gdal_GDALWarp_get_1block_1size(JNIEnv *en
 }
 
 JNIEXPORT jint JNICALL Java_com_azavea_gdal_GDALWarp_get_1histogram(JNIEnv *env, jclass obj, jlong token, jint dataset, jint attempts, jint band_number,
-                                                                    jdouble dfMin, jdouble dfMax, jlongArray _panHistogram, jboolean bIncludeOutOfRange,
-                                                                    jboolean bApproxOK)
+                                                                    jdouble lower, jdouble upper, jlongArray _hist, jboolean include_out_of_range,
+                                                                    jboolean approx_ok)
 {
-    jlong *panHistogram = (*env)->GetLongArrayElements(env, _panHistogram, NULL);
-    jint nBuckets = (*env)->GetArrayLength(env, _panHistogram);
+    jlong *hist = (*env)->GetLongArrayElements(env, _hist, NULL);
+    jint num_buckets = (*env)->GetArrayLength(env, _hist);
 
     jint retval = get_histogram(token, dataset, attempts, copies, band_number,
-                                dfMin, dfMax, nBuckets, (unsigned long long int *)panHistogram,
-                                bIncludeOutOfRange, bApproxOK);
-    (*env)->ReleaseLongArrayElements(env, _panHistogram, panHistogram, 0);
+                                lower, upper, num_buckets, (unsigned long long int *)hist,
+                                include_out_of_range, approx_ok);
+    (*env)->ReleaseLongArrayElements(env, _hist, hist, 0);
 
     return retval;
 }

--- a/src/com_azavea_gdal_GDALWarp.c
+++ b/src/com_azavea_gdal_GDALWarp.c
@@ -132,6 +132,21 @@ JNIEXPORT jint JNICALL Java_com_azavea_gdal_GDALWarp_get_1block_1size(JNIEnv *en
     return retval;
 }
 
+JNIEXPORT jint JNICALL Java_com_azavea_gdal_GDALWarp_get_1histogram
+  (JNIEnv *env, jclass obj, jlong token, jint dataset, jint attempts, jint band_number,
+   jdouble dfMin, jdouble dfMax, jint nBuckets, jlongArray _panHistogram, jboolean bIncludeOutOfRange,
+   jboolean bApproxOK)
+{
+    jlong *panHistogram = (*env)->GetLongArrayElements(env, _panHistogram, NULL);
+
+    jint retval = get_histogram(token, dataset, attempts, copies, band_number,
+				dfMin, dfMax, nBuckets, (unsigned long long int *)panHistogram,
+				bIncludeOutOfRange, bApproxOK);
+    (*env)->ReleaseLongArrayElements(env, _panHistogram, panHistogram, 0);
+
+    return retval;
+}
+
 JNIEXPORT jint JNICALL Java_com_azavea_gdal_GDALWarp_get_1offset(JNIEnv *env, jclass obj,
                                                                  jlong token,
                                                                  jint dataset,

--- a/src/com_azavea_gdal_GDALWarp.c
+++ b/src/com_azavea_gdal_GDALWarp.c
@@ -137,9 +137,10 @@ JNIEXPORT jint JNICALL Java_com_azavea_gdal_GDALWarp_get_1histogram(JNIEnv *env,
                                                                     jboolean bApproxOK)
 {
     jlong *panHistogram = (*env)->GetLongArrayElements(env, _panHistogram, NULL);
+    jint nBuckets = (*env)->GetArrayLength(env, _panHistogram);
 
     jint retval = get_histogram(token, dataset, attempts, copies, band_number,
-                                dfMin, dfMax, (unsigned long long int *)panHistogram,
+                                dfMin, dfMax, nBuckets, (unsigned long long int *)panHistogram,
                                 bIncludeOutOfRange, bApproxOK);
     (*env)->ReleaseLongArrayElements(env, _panHistogram, panHistogram, 0);
 

--- a/src/com_azavea_gdal_GDALWarp.c
+++ b/src/com_azavea_gdal_GDALWarp.c
@@ -132,16 +132,15 @@ JNIEXPORT jint JNICALL Java_com_azavea_gdal_GDALWarp_get_1block_1size(JNIEnv *en
     return retval;
 }
 
-JNIEXPORT jint JNICALL Java_com_azavea_gdal_GDALWarp_get_1histogram
-  (JNIEnv *env, jclass obj, jlong token, jint dataset, jint attempts, jint band_number,
-   jdouble dfMin, jdouble dfMax, jint nBuckets, jlongArray _panHistogram, jboolean bIncludeOutOfRange,
-   jboolean bApproxOK)
+JNIEXPORT jint JNICALL Java_com_azavea_gdal_GDALWarp_get_1histogram(JNIEnv *env, jclass obj, jlong token, jint dataset, jint attempts, jint band_number,
+                                                                    jdouble dfMin, jdouble dfMax, jlongArray _panHistogram, jboolean bIncludeOutOfRange,
+                                                                    jboolean bApproxOK)
 {
     jlong *panHistogram = (*env)->GetLongArrayElements(env, _panHistogram, NULL);
 
     jint retval = get_histogram(token, dataset, attempts, copies, band_number,
-				dfMin, dfMax, nBuckets, (unsigned long long int *)panHistogram,
-				bIncludeOutOfRange, bApproxOK);
+                                dfMin, dfMax, (unsigned long long int *)panHistogram,
+                                bIncludeOutOfRange, bApproxOK);
     (*env)->ReleaseLongArrayElements(env, _panHistogram, panHistogram, 0);
 
     return retval;

--- a/src/locked_dataset.hpp
+++ b/src/locked_dataset.hpp
@@ -181,20 +181,21 @@ public:
      *
      * @param dataset The index of the dataset (source == 0, warped == 1)
      * @param band_number The band in question
-     * @param dfMin the lower bound of the histogram
-     * @param dfMax the upper bound of the histogram
-     * @param panHistogram array into which the histogram totals are placed
-     * @param bIncludeOutOfRange Whether to map out of range values into the first/last buckets
-     * @param bApproxOK Whether to accept an approximate histogram. With COGs, will cause the use of overviews
+     * @param lower the lower bound of the histogram
+     * @param upper the upper bound of the histogram
+     * @param num_buckets The number of histogram buckts
+     * @param hist array into which the histogram totals are placed
+     * @param include_out_of_range Whether to map out of range values into the first/last buckets
+     * @param approx_ok Whether to accept an approximate histogram. With COGs, will cause the use of overviews
      */
     int get_histogram(int dataset, int band_number,
-                      double dfMin, double dfMax,
-                      int nBuckets, GUIntBig *panHistogram, int bIncludeOutOfRange, int bApproxOK)
+                      double lower, double upper,
+                      int num_buckets, GUIntBig *hist, int include_out_of_range, int approx_ok)
     {
         TRYLOCK
         GDALRasterBandH bandh = GDALGetRasterBand(m_datasets[dataset], band_number);
-        auto retval = GDALGetRasterHistogramEx(bandh, dfMin, dfMax, nBuckets,
-                                               panHistogram, bIncludeOutOfRange, bApproxOK, NULL, NULL);
+        auto retval = GDALGetRasterHistogramEx(bandh, lower, upper, num_buckets,
+                                               hist, include_out_of_range, approx_ok, NULL, NULL);
         UNLOCK
         if (retval == CE_None)
         {

--- a/src/locked_dataset.hpp
+++ b/src/locked_dataset.hpp
@@ -163,7 +163,7 @@ public:
      * Get the block size of the given band.
      *
      * @param dataset The index of the dataset (source == 0, warped == 1)
-     * @            param band_number The band          in question
+     * @param band_number The band in question
      * @param width The return-location of the block width
      * @param height The return-location of the block height
      * @return ATTEMPT_SUCCESSFUL, DATASET_LOCKED, or a negative CPLErrorNum
@@ -178,7 +178,7 @@ public:
     }
 
     /** Get a histogram of a band
-     * 
+     *
      * @param dataset The index of the dataset (source == 0, warped == 1)
      * @param band_number The band in question
      * @param dfMin the lower bound of the histogram
@@ -228,7 +228,7 @@ public:
      * Get the scale of the given band.
      *
      * @param dataset The index of the dataset (source == 0, warped == 1)
-     * @            param band_number The band          in question
+     * @param band_number The band in question
      * @param scale The return-location of the scale
      * @param success The return-location of the success flag
      * @return ATTEMPT_SUCCESSFUL, DATASET_LOCKED, or a negative CPLErrorNum
@@ -246,7 +246,7 @@ public:
      * Get the color interpretation of the given band.
      *
      * @param dataset The index of the dataset (source == 0, warped == 1)
-     * @            param band_number The band          in question
+     * @param band_number The band in question
      * @param color_interp The return-slot for the integer-coded color
      *                     interpretation
      * @return ATTEMPT_SUCCESSFUL, DATASET_LOCKED, or a negative CPLErrorNum
@@ -262,10 +262,10 @@ public:
 
     /**
      * Get the widths and heights of all overviews associated with the
-     * first band of the underlying warped dataset          .
+     * first band of the underlying warped dataset.
      *
      * @param dataset The index of the dataset (source == 0, warped == 1)
-     * @            param band_number The band          in question
+     * @param band_number The band in question
      * @param widths The array in which to return the widths
      * @param heights The array in which to return the heights
      * @param max_length The maximum of number of widths and heights to return
@@ -291,10 +291,10 @@ public:
     }
 
     /**
-     * Get the CRS of the underlying warped dataset in PROJ.4           .
+     * Get the CRS of the underlying warped dataset in PROJ.4.
      *
      * @param dataset The index of the dataset (source == 0, warped == 1)
-     * @param           crs The location at-which           to return the PROJ.4 string
+     * @param crs The location at-which to return the PROJ.4 string
      * @param max_size The maximum PROJ.4 string size
      * @return ATTEMPT_SUCCESSFUL, DATASET_LOCKED, or a negative CPLErrorNum
      */
@@ -312,10 +312,10 @@ public:
     }
 
     /**
-     * Get the CRS of the underlying warped dataset in WKT          .
+     * Get the CRS of the underlying warped dataset in WKT.
      *
      * @param dataset The index of the dataset (source == 0, warped == 1)
-     * @param           crs The location at-which           to return the WKT string
+     * @param crs The location at-which to return the WKT string
      * @param max_size The maximum WKT string size
      * @return ATTEMPT_SUCCESSFUL, DATASET_LOCKED, or a negative CPLErrorNum
      */
@@ -329,10 +329,10 @@ public:
 
     /**
      * Get the NODATA value associated with a particular band of the
-     * underlying warped dataset            .
+     * underlying warped dataset.
      *
      * @param dataset The index of the dataset (source == 0, warped == 1)
-     * @            param band_number The band          in question
+     * @param band_number The band in question
      * @param nodata The return-location for the nodata value
      * @param success The return slot for the "is there nodata" value
      * @return ATTEMPT_SUCCESSFUL, DATASET_LOCKED, or a negative CPLErrorNum
@@ -348,10 +348,10 @@ public:
 
     /**
      * Get the data type of a particular band of the underlying warped
-     * dataset          .
+     * dataset.
      *
      * @param dataset The index of the dataset (source == 0, warped == 1)
-     * @            param band_number The band          in question
+     * @param band_number The band in question
      * @param data_type The type of the band in question
      * @return ATTEMPT_SUCCESSFUL, DATASET_LOCKED, or a negative CPLErrorNum
      */
@@ -366,10 +366,10 @@ public:
 
     /**
      * Get the number of raster bands in the underlying warped
-     * dataset          .
+     * dataset.
      *
      * @param dataset The index of the dataset (source == 0, warped == 1)
-     * @            param band_count The return         -location for the integer band count
+     * @param band_count The return-location for the integer band count
      * @return ATTEMPT_SUCCESSFUL, DATASET_LOCKED, or a negative CPLErrorNum
      */
     int get_band_count(int dataset, int *band_count) const
@@ -381,10 +381,10 @@ public:
     }
 
     /**
-     * Get the transform of the underlying warped dataset           .
+     * Get the transform of the underlying warped dataset.
      *
      * @param dataset The index of the dataset (source == 0, warped == 1)
-     * @            param transform The return-         location of the transform
+     * @param transform The return-location of the transform
      * @return ATTEMPT_SUCCESSFUL, DATASET_LOCKED, or a negative CPLErrorNum
      */
     int get_transform(int dataset, double transform[6]) const
@@ -396,10 +396,10 @@ public:
     }
 
     /**
-     * Get the width and height of the underlying warped dataset            .
+     * Get the width and height of the underlying warped dataset.
      *
      * @param dataset The index of the dataset (source == 0, warped == 1)
-     * @            param width The return-location             for the width
+     * @param width The return-location for the width
      * @param height The return-location for the height
      * @return ATTEMPT_SUCCESSFUL, DATASET_LOCKED, or a negative CPLErrorNum
      */
@@ -417,7 +417,7 @@ public:
      * Get the maximum and minimum values appearing in the requested band.
      *
      * @param dataset The index of the dataset (source == 0, warped == 1)
-     * @            param band_number The band          to query
+     * @param band_number The band to query
      * @param approx_okay A flag indicating whether approximate min
      *                    and max values are okay
      * @param minmax The return-array for the minimum and maximum
@@ -449,7 +449,7 @@ public:
      * Get the list of metadata domain lists.
      *
      * @param dataset The index of the dataset (source == 0, warped == 1)
-     * @            param band_number The band to           query (zero for the file itself)
+     * @param band_number The band to query (zero for the file itself)
      * @param domain_list The return-location for the list of strings
      * @return ATTEMPT_SUCCESSFUL, DATASET_LOCKED, or a negative CPLErrorNum
      */
@@ -464,7 +464,7 @@ public:
         else
         {
             GDALRasterBandH band = GDALGetRasterBand(m_datasets[dataset], band_number);
-            // Must be freed            with CSLDestroy
+            // Must be freed with CSLDestroy
             *domain_list = GDALGetMetadataDomainList(band);
         }
         UNLOCK
@@ -482,7 +482,7 @@ public:
      * Get the metadata found in a particular metadata domain.
      *
      * @param dataset The index of the dataset (source == 0, warped == 1)
-     * @            param band_number The band to           query (zero for the file itself)
+     * @param band_number The band to query (zero for the file itself)
      * @param domain The metadata domain to query
      * @param list The return-location for the list of strings
      * @return ATTEMPT_SUCCESSFUL, DATASET_LOCKED, or a negative CPLErrorNum
@@ -514,7 +514,7 @@ public:
      * Get a particular metadata value associated with a key.
      *
      * @param dataset The index of the dataset (source == 0, warped == 1)
-     * @            param band_number The band to           query (zero for the file itself)
+     * @param band_number The band to query (zero for the file itself)
      * @param key The key of the key ⨯ value metadata pair
      * @param doamin The metadata domain to query
      * @param value The return-location for the value of the key ⨯ value pair
@@ -545,12 +545,12 @@ public:
 
     /**
      * Read pixels from the underlying dataset.  This is more-or-less
-     * a direct wrapper of the          GDALRasterIO function see
+     * a direct wrapper of the GDALRasterIO function see
      * https://gdal.org/api/raster_c_api.html?highlight=rasterio#_CPPv419GDALDatasetRasterIO12GDALDatasetH10GDALRWFlagiiiiPvii12GDALDataTypeiPiiii
      * for more information.
      *
      * @param dataset The index of the dataset (source == 0, warped == 1)
-     * @            param src_window The pixel-         space coordinates of the upper-left
+     * @param src_window The pixel-space coordinates of the upper-left
      *                   corner of the source window (the first two
      *                   entries) and the width and height of the
      *                   source window (the last two entries)
@@ -599,7 +599,7 @@ public:
 
     /**
      * Is the dataset valid?
-                 */
+     */
     bool valid() const
     {
         auto src = m_datasets[SOURCE];
@@ -609,7 +609,7 @@ public:
 
     /**
      * Increment the reference count of this dataset.
-                 */
+     */
     void inc()
     {
         m_use_count++;
@@ -617,14 +617,14 @@ public:
 
     /**
      * Decrement the reference count of this dataset.
-                 */
+     */
     void dec()
     {
         m_use_count--;
     }
 
     /**
-     * Answer "true" iff this dataset is unused and safe to delete          .
+     * Answer "true" iff this dataset is unused and safe to delete.
      *
      * @return A boolean meeting the above description
      */
@@ -645,7 +645,7 @@ public:
 
     /**
      * Unlock this dataset (use only if previously locked for deletion).
-                 */
+     */
     void unlock_for_nondeletion()
     {
         UNLOCK
@@ -654,7 +654,7 @@ public:
 private:
     /**
      * A function to open a GDAL dataset answering the given warp
-     * options.  Should only            be called from constructors.
+     * options.  Should only be called from constructors.
      */
     void open()
     {

--- a/src/locked_dataset.hpp
+++ b/src/locked_dataset.hpp
@@ -177,6 +177,26 @@ public:
         SUCCESS
     }
 
+    /** Get a histogram of a band
+     */
+    int get_histogram(int dataset, int band_number,
+		      double dfMin, double dfMax,
+		      int nBuckets, GUIntBig *panHistogram, int bIncludeOutOfRange, int bApproxOK)
+    {
+        TRYLOCK
+        GDALRasterBandH bandh = GDALGetRasterBand(m_datasets[dataset], band_number);
+        auto retval = GDALGetRasterHistogramEx(bandh, dfMin, dfMax, nBuckets, panHistogram, bIncludeOutOfRange, bApproxOK, NULL, NULL);
+        UNLOCK
+        if (retval == CE_None)
+        {
+            SUCCESS
+        }
+        else
+        {
+            FAILURE
+        }
+    }
+
     /**
      * Get the offset of the given band.
      *

--- a/src/locked_dataset.hpp
+++ b/src/locked_dataset.hpp
@@ -178,6 +178,14 @@ public:
     }
 
     /** Get a histogram of a band
+     * 
+     * @param dataset The index of the dataset (source == 0, warped == 1)
+     * @param band_number The band in question
+     * @param dfMin the lower bound of the histogram
+     * @param dfMax the upper bound of the histogram
+     * @param panHistogram array into which the histogram totals are placed
+     * @param bIncludeOutOfRange Whether to map out of range values into the first/last buckets
+     * @param bApproxOK Whether to accept an approximate histogram. With COGs, will cause the use of overviews
      */
     int get_histogram(int dataset, int band_number,
                       double dfMin, double dfMax,
@@ -185,7 +193,10 @@ public:
     {
         TRYLOCK
         GDALRasterBandH bandh = GDALGetRasterBand(m_datasets[dataset], band_number);
-        auto retval = GDALGetRasterHistogramEx(bandh, dfMin, dfMax, sizeof(panHistogram),
+        printf("Histogram container size is: %ld", sizeof(panHistogram) / sizeof(panHistogram[0]));
+        // TODO should be length of panHistogram, but can't get that to evaluate to what I think it
+        // should be :thinking_face:
+        auto retval = GDALGetRasterHistogramEx(bandh, dfMin, dfMax, 256,
                                                panHistogram, bIncludeOutOfRange, bApproxOK, NULL, NULL);
         UNLOCK
         if (retval == CE_None)
@@ -202,7 +213,7 @@ public:
      * Get the offset of the given band.
      *
      * @param dataset The index of the dataset (source == 0, warped == 1)
-     * @            param band_number The band          in question
+     * @param band_number The band in question
      * @param offset The return-location of the offset
      * @param success The return-location of the success flag
      * @return ATTEMPT_SUCCESSFUL, DATASET_LOCKED, or a negative CPLErrorNum

--- a/src/locked_dataset.hpp
+++ b/src/locked_dataset.hpp
@@ -189,14 +189,11 @@ public:
      */
     int get_histogram(int dataset, int band_number,
                       double dfMin, double dfMax,
-                      GUIntBig *panHistogram, int bIncludeOutOfRange, int bApproxOK)
+                      int nBuckets, GUIntBig *panHistogram, int bIncludeOutOfRange, int bApproxOK)
     {
         TRYLOCK
         GDALRasterBandH bandh = GDALGetRasterBand(m_datasets[dataset], band_number);
-        printf("Histogram container size is: %ld", sizeof(panHistogram) / sizeof(panHistogram[0]));
-        // TODO should be length of panHistogram, but can't get that to evaluate to what I think it
-        // should be :thinking_face:
-        auto retval = GDALGetRasterHistogramEx(bandh, dfMin, dfMax, 256,
+        auto retval = GDALGetRasterHistogramEx(bandh, dfMin, dfMax, nBuckets,
                                                panHistogram, bIncludeOutOfRange, bApproxOK, NULL, NULL);
         UNLOCK
         if (retval == CE_None)

--- a/src/locked_dataset.hpp
+++ b/src/locked_dataset.hpp
@@ -163,7 +163,7 @@ public:
      * Get the block size of the given band.
      *
      * @param dataset The index of the dataset (source == 0, warped == 1)
-     * @param band_number The band in question
+     * @            param band_number The band          in question
      * @param width The return-location of the block width
      * @param height The return-location of the block height
      * @return ATTEMPT_SUCCESSFUL, DATASET_LOCKED, or a negative CPLErrorNum
@@ -180,12 +180,13 @@ public:
     /** Get a histogram of a band
      */
     int get_histogram(int dataset, int band_number,
-		      double dfMin, double dfMax,
-		      int nBuckets, GUIntBig *panHistogram, int bIncludeOutOfRange, int bApproxOK)
+                      double dfMin, double dfMax,
+                      GUIntBig *panHistogram, int bIncludeOutOfRange, int bApproxOK)
     {
         TRYLOCK
         GDALRasterBandH bandh = GDALGetRasterBand(m_datasets[dataset], band_number);
-        auto retval = GDALGetRasterHistogramEx(bandh, dfMin, dfMax, nBuckets, panHistogram, bIncludeOutOfRange, bApproxOK, NULL, NULL);
+        auto retval = GDALGetRasterHistogramEx(bandh, dfMin, dfMax, sizeof(panHistogram),
+                                               panHistogram, bIncludeOutOfRange, bApproxOK, NULL, NULL);
         UNLOCK
         if (retval == CE_None)
         {
@@ -201,7 +202,7 @@ public:
      * Get the offset of the given band.
      *
      * @param dataset The index of the dataset (source == 0, warped == 1)
-     * @param band_number The band in question
+     * @            param band_number The band          in question
      * @param offset The return-location of the offset
      * @param success The return-location of the success flag
      * @return ATTEMPT_SUCCESSFUL, DATASET_LOCKED, or a negative CPLErrorNum
@@ -219,7 +220,7 @@ public:
      * Get the scale of the given band.
      *
      * @param dataset The index of the dataset (source == 0, warped == 1)
-     * @param band_number The band in question
+     * @            param band_number The band          in question
      * @param scale The return-location of the scale
      * @param success The return-location of the success flag
      * @return ATTEMPT_SUCCESSFUL, DATASET_LOCKED, or a negative CPLErrorNum
@@ -237,7 +238,7 @@ public:
      * Get the color interpretation of the given band.
      *
      * @param dataset The index of the dataset (source == 0, warped == 1)
-     * @param band_number The band in question
+     * @            param band_number The band          in question
      * @param color_interp The return-slot for the integer-coded color
      *                     interpretation
      * @return ATTEMPT_SUCCESSFUL, DATASET_LOCKED, or a negative CPLErrorNum
@@ -253,10 +254,10 @@ public:
 
     /**
      * Get the widths and heights of all overviews associated with the
-     * first band of the underlying warped dataset.
+     * first band of the underlying warped dataset          .
      *
      * @param dataset The index of the dataset (source == 0, warped == 1)
-     * @param band_number The band in question
+     * @            param band_number The band          in question
      * @param widths The array in which to return the widths
      * @param heights The array in which to return the heights
      * @param max_length The maximum of number of widths and heights to return
@@ -282,10 +283,10 @@ public:
     }
 
     /**
-     * Get the CRS of the underlying warped dataset in PROJ.4.
+     * Get the CRS of the underlying warped dataset in PROJ.4           .
      *
      * @param dataset The index of the dataset (source == 0, warped == 1)
-     * @param crs The location at-which to return the PROJ.4 string
+     * @param           crs The location at-which           to return the PROJ.4 string
      * @param max_size The maximum PROJ.4 string size
      * @return ATTEMPT_SUCCESSFUL, DATASET_LOCKED, or a negative CPLErrorNum
      */
@@ -303,10 +304,10 @@ public:
     }
 
     /**
-     * Get the CRS of the underlying warped dataset in WKT.
+     * Get the CRS of the underlying warped dataset in WKT          .
      *
      * @param dataset The index of the dataset (source == 0, warped == 1)
-     * @param crs The location at-which to return the WKT string
+     * @param           crs The location at-which           to return the WKT string
      * @param max_size The maximum WKT string size
      * @return ATTEMPT_SUCCESSFUL, DATASET_LOCKED, or a negative CPLErrorNum
      */
@@ -320,10 +321,10 @@ public:
 
     /**
      * Get the NODATA value associated with a particular band of the
-     * underlying warped dataset.
+     * underlying warped dataset            .
      *
      * @param dataset The index of the dataset (source == 0, warped == 1)
-     * @param band_number The band in question
+     * @            param band_number The band          in question
      * @param nodata The return-location for the nodata value
      * @param success The return slot for the "is there nodata" value
      * @return ATTEMPT_SUCCESSFUL, DATASET_LOCKED, or a negative CPLErrorNum
@@ -339,10 +340,10 @@ public:
 
     /**
      * Get the data type of a particular band of the underlying warped
-     * dataset.
+     * dataset          .
      *
      * @param dataset The index of the dataset (source == 0, warped == 1)
-     * @param band_number The band in question
+     * @            param band_number The band          in question
      * @param data_type The type of the band in question
      * @return ATTEMPT_SUCCESSFUL, DATASET_LOCKED, or a negative CPLErrorNum
      */
@@ -357,10 +358,10 @@ public:
 
     /**
      * Get the number of raster bands in the underlying warped
-     * dataset.
+     * dataset          .
      *
      * @param dataset The index of the dataset (source == 0, warped == 1)
-     * @param band_count The return-location for the integer band count
+     * @            param band_count The return         -location for the integer band count
      * @return ATTEMPT_SUCCESSFUL, DATASET_LOCKED, or a negative CPLErrorNum
      */
     int get_band_count(int dataset, int *band_count) const
@@ -372,10 +373,10 @@ public:
     }
 
     /**
-     * Get the transform of the underlying warped dataset.
+     * Get the transform of the underlying warped dataset           .
      *
      * @param dataset The index of the dataset (source == 0, warped == 1)
-     * @param transform The return-location of the transform
+     * @            param transform The return-         location of the transform
      * @return ATTEMPT_SUCCESSFUL, DATASET_LOCKED, or a negative CPLErrorNum
      */
     int get_transform(int dataset, double transform[6]) const
@@ -387,10 +388,10 @@ public:
     }
 
     /**
-     * Get the width and height of the underlying warped dataset.
+     * Get the width and height of the underlying warped dataset            .
      *
      * @param dataset The index of the dataset (source == 0, warped == 1)
-     * @param width The return-location for the width
+     * @            param width The return-location             for the width
      * @param height The return-location for the height
      * @return ATTEMPT_SUCCESSFUL, DATASET_LOCKED, or a negative CPLErrorNum
      */
@@ -408,7 +409,7 @@ public:
      * Get the maximum and minimum values appearing in the requested band.
      *
      * @param dataset The index of the dataset (source == 0, warped == 1)
-     * @param band_number The band to query
+     * @            param band_number The band          to query
      * @param approx_okay A flag indicating whether approximate min
      *                    and max values are okay
      * @param minmax The return-array for the minimum and maximum
@@ -440,7 +441,7 @@ public:
      * Get the list of metadata domain lists.
      *
      * @param dataset The index of the dataset (source == 0, warped == 1)
-     * @param band_number The band to query (zero for the file itself)
+     * @            param band_number The band to           query (zero for the file itself)
      * @param domain_list The return-location for the list of strings
      * @return ATTEMPT_SUCCESSFUL, DATASET_LOCKED, or a negative CPLErrorNum
      */
@@ -455,7 +456,7 @@ public:
         else
         {
             GDALRasterBandH band = GDALGetRasterBand(m_datasets[dataset], band_number);
-            // Must be freed with CSLDestroy
+            // Must be freed            with CSLDestroy
             *domain_list = GDALGetMetadataDomainList(band);
         }
         UNLOCK
@@ -473,7 +474,7 @@ public:
      * Get the metadata found in a particular metadata domain.
      *
      * @param dataset The index of the dataset (source == 0, warped == 1)
-     * @param band_number The band to query (zero for the file itself)
+     * @            param band_number The band to           query (zero for the file itself)
      * @param domain The metadata domain to query
      * @param list The return-location for the list of strings
      * @return ATTEMPT_SUCCESSFUL, DATASET_LOCKED, or a negative CPLErrorNum
@@ -505,7 +506,7 @@ public:
      * Get a particular metadata value associated with a key.
      *
      * @param dataset The index of the dataset (source == 0, warped == 1)
-     * @param band_number The band to query (zero for the file itself)
+     * @            param band_number The band to           query (zero for the file itself)
      * @param key The key of the key ⨯ value metadata pair
      * @param doamin The metadata domain to query
      * @param value The return-location for the value of the key ⨯ value pair
@@ -536,12 +537,12 @@ public:
 
     /**
      * Read pixels from the underlying dataset.  This is more-or-less
-     * a direct wrapper of the GDALRasterIO function see
+     * a direct wrapper of the          GDALRasterIO function see
      * https://gdal.org/api/raster_c_api.html?highlight=rasterio#_CPPv419GDALDatasetRasterIO12GDALDatasetH10GDALRWFlagiiiiPvii12GDALDataTypeiPiiii
      * for more information.
      *
      * @param dataset The index of the dataset (source == 0, warped == 1)
-     * @param src_window The pixel-space coordinates of the upper-left
+     * @            param src_window The pixel-         space coordinates of the upper-left
      *                   corner of the source window (the first two
      *                   entries) and the width and height of the
      *                   source window (the last two entries)
@@ -590,7 +591,7 @@ public:
 
     /**
      * Is the dataset valid?
-     */
+                 */
     bool valid() const
     {
         auto src = m_datasets[SOURCE];
@@ -600,7 +601,7 @@ public:
 
     /**
      * Increment the reference count of this dataset.
-     */
+                 */
     void inc()
     {
         m_use_count++;
@@ -608,14 +609,14 @@ public:
 
     /**
      * Decrement the reference count of this dataset.
-     */
+                 */
     void dec()
     {
         m_use_count--;
     }
 
     /**
-     * Answer "true" iff this dataset is unused and safe to delete.
+     * Answer "true" iff this dataset is unused and safe to delete          .
      *
      * @return A boolean meeting the above description
      */
@@ -636,7 +637,7 @@ public:
 
     /**
      * Unlock this dataset (use only if previously locked for deletion).
-     */
+                 */
     void unlock_for_nondeletion()
     {
         UNLOCK
@@ -645,7 +646,7 @@ public:
 private:
     /**
      * A function to open a GDAL dataset answering the given warp
-     * options.  Should only be called from constructors.
+     * options.  Should only            be called from constructors.
      */
     void open()
     {

--- a/src/main/GDALWarpThreadTest.java
+++ b/src/main/GDALWarpThreadTest.java
@@ -1,4 +1,3 @@
-
 /*
  * Copyright 2019 Azavea
  *

--- a/src/main/GDALWarpThreadTest.java
+++ b/src/main/GDALWarpThreadTest.java
@@ -237,11 +237,11 @@ class GDALWarpThreadTest extends Thread {
 
         // Histogram
         {
-            long[] histContainer = new long[256];
-            GDALWarp.get_histogram(token, GDALWarp.SOURCE, 0, 1, -0.5, 255.5, histContainer, true, false);
+            long[] hist = new long[256];
+            GDALWarp.get_histogram(token, GDALWarp.SOURCE, 0, 1, -0.5, 255.5, hist, true, false);
             System.out.println(ANSI_BLUE + "Exact histogram: " + ANSI_GREEN);
-            for (int i = 0; i < histContainer.length; ++i) {
-                System.out.print(histContainer[i] + " ");
+            for (int i = 0; i < hist.length; ++i) {
+                System.out.print(hist[i] + " ");
             }
             System.out.println("");
         }

--- a/src/main/GDALWarpThreadTest.java
+++ b/src/main/GDALWarpThreadTest.java
@@ -124,8 +124,7 @@ class GDALWarpThreadTest extends Thread {
         {
             String version = GDALWarp.get_version_info("--version");
             System.out.println(ANSI_BLUE + "Version info: " + ANSI_GREEN + version + ANSI_RESET);
-            System.out
-                    .println(ANSI_BLUE + "Version string length: " + ANSI_GREEN + version.length() + ANSI_RESET);
+            System.out.println(ANSI_BLUE + "Version string length: " + ANSI_GREEN + version.length() + ANSI_RESET);
         }
 
         // License
@@ -157,7 +156,8 @@ class GDALWarpThreadTest extends Thread {
 
         // noop
         {
-            System.out.println(ANSI_BLUE + "noop: " + ANSI_GREEN + GDALWarp.noop(token, GDALWarp.SOURCE, 0) + ANSI_RESET);
+            System.out
+                    .println(ANSI_BLUE + "noop: " + ANSI_GREEN + GDALWarp.noop(token, GDALWarp.SOURCE, 0) + ANSI_RESET);
         }
 
         // Color Interpretation
@@ -236,18 +236,16 @@ class GDALWarpThreadTest extends Thread {
                     .println(ANSI_BLUE + "Warped block size: " + ANSI_GREEN + width[0] + " " + height[0] + ANSI_RESET);
         }
 
-	// Histogram
-	{
-	    long[] histContainer = new long[256];
-	    GDALWarp.get_histogram(token, GDALWarp.SOURCE, 0, 1, -0.5, 255.5, 256, histContainer,
-				   true, false);
-	    System.out
-		.println(ANSI_BLUE + "Exact histogram: " + ANSI_GREEN);
+        // Histogram
+        {
+            long[] histContainer = new long[256];
+            GDALWarp.get_histogram(token, GDALWarp.SOURCE, 0, 1, -0.5, 255.5, histContainer, true, false);
+            System.out.println(ANSI_BLUE + "Exact histogram: " + ANSI_GREEN);
             for (int i = 0; i < histContainer.length; ++i) {
-		System.out.print(histContainer[i] + " ");
-	    }
-	    System.out.println("");
-	}
+                System.out.print(histContainer[i] + " ");
+            }
+            System.out.println("");
+        }
 
         // Offset
         {

--- a/src/main/GDALWarpThreadTest.java
+++ b/src/main/GDALWarpThreadTest.java
@@ -236,6 +236,19 @@ class GDALWarpThreadTest extends Thread {
                     .println(ANSI_BLUE + "Warped block size: " + ANSI_GREEN + width[0] + " " + height[0] + ANSI_RESET);
         }
 
+	// Histogram
+	{
+	    long[] histContainer = new long[256];
+	    GDALWarp.get_histogram(token, GDALWarp.SOURCE, 0, 1, -0.5, 255.5, 256, histContainer,
+				   true, false);
+	    System.out
+		.println(ANSI_BLUE + "Exact histogram: " + ANSI_GREEN);
+            for (int i = 0; i < histContainer.length; ++i) {
+		System.out.print(histContainer[i] + " ");
+	    }
+	    System.out.println("");
+	}
+
         // Offset
         {
             double[] offset = new double[1];

--- a/src/main/java/com/azavea/gdal/GDALWarp.java
+++ b/src/main/java/com/azavea/gdal/GDALWarp.java
@@ -159,24 +159,24 @@ public class GDALWarp {
 
         /**
          * Get the histogram for a given band
-         * 
-         * @param token              A token associated with some uri, options pair
-         * @param dataset            0 (or GDALWarp::SOURCE) for the source dataset, 1
-         *                           (or GDALWarp::WARPED) for the warped dataset
-         * @param attempts           The number of attempts to make before giving up
-         * @param band_number        The band in question
-         * @param min                The minimum bin for the histogram
-         * @param max                The maximum bin for the histogram
-         * @param histogramContainer The array to hold the result of the histogram
-         *                           calculation
-         * @param includeOutOfRange  Whether to map out of range values into the
-         *                           first/last buckets
-         * @param approxOK           Whether to accept an approximate histogram. With
-         *                           COGs, will cause the use of overviews
+         *
+         * @param token                A token associated with some uri, options pair
+         * @param dataset              0 (or GDALWarp::SOURCE) for the source dataset, 1
+         *                             (or GDALWarp::WARPED) for the warped dataset
+         * @param attempts             The number of attempts to make before giving up
+         * @param band_number          The band in question
+         * @param min                  The minimum bin for the histogram
+         * @param max                  The maximum bin for the histogram
+         * @param histogram_container  The array to hold the result of the histogram
+         *                             calculation
+         * @param include_out_of_range Whether to map out of range values into the
+         *                             first/last buckets
+         * @param approx_ok            Whether to accept an approximate histogram. With
+         *                             COGs, will cause the use of overviews
          */
         public static native int get_histogram(long token, int dataset, int attempts, /* */
-                        int band_number, double min, double max, long[] histogramContainer, boolean includeOutOfRange,
-                        boolean approxOK);
+                        int band_number, double min, double max, long[] histogram_container,
+                        boolean include_out_of_range, boolean approx_ok);
 
         /**
          * Get the offset of the given band.

--- a/src/main/java/com/azavea/gdal/GDALWarp.java
+++ b/src/main/java/com/azavea/gdal/GDALWarp.java
@@ -157,6 +157,11 @@ public class GDALWarp {
         public static native int get_block_size(long token, int dataset, int attempts, /* */
                         int band_number, int[] width, int[] height);
 
+	public static native int get_histogram(long token, int dataset, int attempts, /* */
+					       int band_number, double dfMin, double dfMax,
+					       int nBuckets, long[] panHistogram,
+					       boolean bIncludeOutOfRange, boolean bApproxOK);
+
         /**
          * Get the offset of the given band.
          *
@@ -171,10 +176,10 @@ public class GDALWarp {
          *         negative error code (upon failure)
          */
         public static native int get_offset(long token, int dataset, int attempts, /* */
-                        int band_number, double[] offset, int[] success);
+					    int band_number, double[] offset, int[] success);
 
-        /**
-         * Get the scale of the given band.
+	/**
+	 * Get the scale of the given band.
          *
          * @param token       A token associated with some uri, options pair
          * @param dataset     0 (or GDALWarp::SOURCE) for the source dataset, 1 (or

--- a/src/main/java/com/azavea/gdal/GDALWarp.java
+++ b/src/main/java/com/azavea/gdal/GDALWarp.java
@@ -157,9 +157,26 @@ public class GDALWarp {
         public static native int get_block_size(long token, int dataset, int attempts, /* */
                         int band_number, int[] width, int[] height);
 
+        /**
+         * Get the histogram for a given band
+         * 
+         * @param token              A token associated with some uri, options pair
+         * @param dataset            0 (or GDALWarp::SOURCE) for the source dataset, 1
+         *                           (or GDALWarp::WARPED) for the warped dataset
+         * @param attempts           The number of attempts to make before giving up
+         * @param band_number        The band in question
+         * @param min                The minimum bin for the histogram
+         * @param max                The maximum bin for the histogram
+         * @param histogramContainer The array to hold the result of the histogram
+         *                           calculation
+         * @param includeOutOfRange  Whether to map out of range values into the
+         *                           first/last buckets
+         * @param approxOK           Whether to accept an approximate histogram. With
+         *                           COGs, will cause the use of overviews
+         */
         public static native int get_histogram(long token, int dataset, int attempts, /* */
-                        int band_number, double dfMin, double dfMax, long[] panHistogram, boolean bIncludeOutOfRange,
-                        boolean bApproxOK);
+                        int band_number, double min, double max, long[] histogramContainer, boolean includeOutOfRange,
+                        boolean approxOK);
 
         /**
          * Get the offset of the given band.

--- a/src/main/java/com/azavea/gdal/GDALWarp.java
+++ b/src/main/java/com/azavea/gdal/GDALWarp.java
@@ -151,16 +151,15 @@ public class GDALWarp {
          * @param band_number The band in question
          * @param width       The return-location of the block width
          * @param height      The return-location of the block height
-         * @return The number of attempts made (upon success) or a
-         *         negative error code (upon failure)
+         * @return The number of attempts made (upon success) or a negative error code
+         *         (upon failure)
          */
         public static native int get_block_size(long token, int dataset, int attempts, /* */
                         int band_number, int[] width, int[] height);
 
-	public static native int get_histogram(long token, int dataset, int attempts, /* */
-					       int band_number, double dfMin, double dfMax,
-					       int nBuckets, long[] panHistogram,
-					       boolean bIncludeOutOfRange, boolean bApproxOK);
+        public static native int get_histogram(long token, int dataset, int attempts, /* */
+                        int band_number, double dfMin, double dfMax, long[] panHistogram, boolean bIncludeOutOfRange,
+                        boolean bApproxOK);
 
         /**
          * Get the offset of the given band.
@@ -172,14 +171,14 @@ public class GDALWarp {
          * @param band_number The band in question
          * @param offset      The return-location of the offset
          * @param success     The return-location of the success flag
-	 * @return The number of attempts made (upon success) or a
-         *         negative error code (upon failure)
+         * @return The number of attempts made (upon success) or a negative error code
+         *         (upon failure)
          */
         public static native int get_offset(long token, int dataset, int attempts, /* */
-					    int band_number, double[] offset, int[] success);
+                        int band_number, double[] offset, int[] success);
 
-	/**
-	 * Get the scale of the given band.
+        /**
+         * Get the scale of the given band.
          *
          * @param token       A token associated with some uri, options pair
          * @param dataset     0 (or GDALWarp::SOURCE) for the source dataset, 1 (or
@@ -188,8 +187,8 @@ public class GDALWarp {
          * @param band_number The band in question
          * @param scale       The return-location of the scale
          * @param success     The return-location of the success flag
-	 * @return The number of attempts made (upon success) or a
-         *         negative error code (upon failure)
+         * @return The number of attempts made (upon success) or a negative error code
+         *         (upon failure)
          */
         public static native int get_scale(long token, int dataset, int attempts, /* */
                         int band_number, double[] scale, int[] success);
@@ -197,12 +196,12 @@ public class GDALWarp {
         /**
          * Get the color interpretation of the given band.
          *
-         * @param token        A token associated with some uri, options pair
-         * @param dataset      0 (or GDALWarp::SOURCE) for the source dataset, 1 (or
-         *                     GDALWarp::WARPED) for the warped dataset
-         * @param attempts     The number of attempts to make before giving up
-	 * @return The number of attempts made (upon success) or a
-         *         negative error code (upon failure)
+         * @param token    A token associated with some uri, options pair
+         * @param dataset  0 (or GDALWarp::SOURCE) for the source dataset, 1 (or
+         *                 GDALWarp::WARPED) for the warped dataset
+         * @param attempts The number of attempts to make before giving up
+         * @return The number of attempts made (upon success) or a negative error code
+         *         (upon failure)
          */
         public static native int noop(long token, int dataset, int attempts);
 
@@ -216,8 +215,8 @@ public class GDALWarp {
          * @param band_number  The band in question
          * @param color_interp The return-slot for the integer-coded color
          *                     interpretation
-	 * @return The number of attempts made (upon success) or a
-         *         negative error code (upon failure)
+         * @return The number of attempts made (upon success) or a negative error code
+         *         (upon failure)
          */
         public static native int get_color_interpretation(long token, int dataset, int attempts, /* */
                         int band_number, int color_interp[]);
@@ -231,8 +230,8 @@ public class GDALWarp {
          * @param attempts    The number of attempts to make before giving up
          * @param band_number The band to query (zero for the file itself)
          * @param domain_list The return-location for the list of strings
-	 * @return The number of attempts made (upon success) or a
-         *         negative error code (upon failure)
+         * @return The number of attempts made (upon success) or a negative error code
+         *         (upon failure)
          */
         public static native int get_metadata_domain_list(long token, int dataset, int attempts, /* */
                         int band_number, byte[][] domain_list);
@@ -247,8 +246,8 @@ public class GDALWarp {
          * @param band_number The band to query (zero for the file itself)
          * @param domain      The metadata domain to query
          * @param list        The return-location for the list of strings
-	 * @return The number of attempts made (upon success) or a
-         *         negative error code (upon failure)
+         * @return The number of attempts made (upon success) or a negative error code
+         *         (upon failure)
          */
         public static native int get_metadata(long token, int dataset, int attempts, /* */
                         int band_number, String domain, byte[][] list);
@@ -264,8 +263,8 @@ public class GDALWarp {
          * @param key         The key of the key, value metadata pair
          * @param domain      The metadata domain to query
          * @param value       The return-location for the value of the key, value pair
-	 * @return The number of attempts made (upon success) or a
-         *         negative error code (upon failure)
+         * @return The number of attempts made (upon success) or a negative error code
+         *         (upon failure)
          */
         public static native int get_metadata_item(long token, int dataset, int attempts, /* */
                         int band_number, String key, String domain, byte[] value);
@@ -284,8 +283,8 @@ public class GDALWarp {
          *                    overviews
          * @param max_length  The maximum number of widths and heights to return
          *                    (nominally the smaller of the lengths of the two arrays)
-	 * @return The number of attempts made (upon success) or a
-	 *         negative error code (upon failure)
+         * @return The number of attempts made (upon success) or a negative error code
+         *         (upon failure)
          */
         public static native int get_overview_widths_heights(long token, int dataset, int attempts, /* */
                         int band_number, int[] widths, int heights[]);
@@ -299,8 +298,8 @@ public class GDALWarp {
          * @param attempts The number of attempts to make before giving up
          * @param crs      The character array in-which to return the PROJ.4 string
          * @param max_size The size of the pre-allocated return buffer
-	 * @return The number of attempts made (upon success) or a
-	 *         negative error code (upon failure)
+         * @return The number of attempts made (upon success) or a negative error code
+         *         (upon failure)
          */
         public static native int get_crs_proj4(long token, int dataset, int attempts, /* */
                         byte[] crs);
@@ -314,8 +313,8 @@ public class GDALWarp {
          * @param attempts The number of attempts to make before giving up
          * @param crs      The character array in-which to return the PROJ.4 string
          * @param max_size The size of the pre-allocated return buffer
-	 * @return The number of attempts made (upon success) or a
-	 *         negative error code (upon failure)
+         * @return The number of attempts made (upon success) or a negative error code
+         *         (upon failure)
          */
         public static native int get_crs_wkt(long token, int dataset, int attempts, /* */
                         byte[] crs);
@@ -331,8 +330,8 @@ public class GDALWarp {
          * @param nodata      The return-location of the NODATA value
          * @param success     The return-location of the success flag (answer whether or
          *                    not there is a NODATA value)
-	 * @return The number of attempts made (upon success) or a
-	 *         negative error code (upon failure)
+         * @return The number of attempts made (upon success) or a negative error code
+         *         (upon failure)
          */
         public static native int get_band_nodata(long token, int dataset, int attempts, /* */
                         int band, double[] nodata, int[] success);
@@ -351,8 +350,8 @@ public class GDALWarp {
          * @param minmax      The return-location of the minimum and maximum
          * @param success     The return-location of the success flag (answer whether or
          *                    not there is a NODATA value)
-	 * @return The number of attempts made (upon success) or a
-         *         negative error code (upon failure)
+         * @return The number of attempts made (upon success) or a negative error code
+         *         (upon failure)
          */
         public static native int get_band_min_max(long token, int dataset, int attempts, /* */
                         int band, boolean approx_okay, double[] minmax, int[] success);
@@ -367,8 +366,8 @@ public class GDALWarp {
          * @param band_number The band of interest
          * @param data_type   The return-location of the band_number type (of integral
          *                    type GDALDataType)
-	 * @return The number of attempts made (upon success) or a
-	 *         negative error code (upon failure)
+         * @return The number of attempts made (upon success) or a negative error code
+         *         (upon failure)
          */
         public static native int get_band_data_type(long token, int dataset, int attempts, /* */
                         int band, int[] data_type);
@@ -381,8 +380,8 @@ public class GDALWarp {
          *                   GDALWarp::WARPED) for the warped dataset
          * @param attempts   The number of attempts to make before giving up
          * @param band_count The return-location of the band count
-	 * @return The number of attempts made (upon success) or a
-	 *         negative error code (upon failure)
+         * @return The number of attempts made (upon success) or a negative error code
+         *         (upon failure)
          */
         public static native int get_band_count(long token, int dataset, int attempts, /* */
                         int[] band_count);
@@ -396,8 +395,8 @@ public class GDALWarp {
          * @param attempts The number of attempts to make before giving up
          * @param width    The return-location of the width
          * @param height   The return-location of the height
-	 * @return The number of attempts made (upon success) or a
-	 *         negative error code (upon failure)
+         * @return The number of attempts made (upon success) or a negative error code
+         *         (upon failure)
          */
         public static native int get_width_height(long token, int dataset, int attempts, /* */
                         int[] width_height);
@@ -409,14 +408,16 @@ public class GDALWarp {
          * @param dataset     0 (or GDALWarp::SOURCE) for the source dataset, 1 (or
          *                    GDALWarp::WARPED) for the warped dataset
          * @param attempts    The number of attempts to make before giving up
-         * @param src_window  Please see https://gdal.org/api/raster_c_api.html?highlight=rasterio#_CPPv419GDALDatasetRasterIO12GDALDatasetH10GDALRWFlagiiiiPvii12GDALDataTypeiPiiii
-         * @param dst_window  Please see https://gdal.org/api/raster_c_api.html?highlight=rasterio#_CPPv419GDALDatasetRasterIO12GDALDatasetH10GDALRWFlagiiiiPvii12GDALDataTypeiPiiii
+         * @param src_window  Please see
+         *                    https://gdal.org/api/raster_c_api.html?highlight=rasterio#_CPPv419GDALDatasetRasterIO12GDALDatasetH10GDALRWFlagiiiiPvii12GDALDataTypeiPiiii
+         * @param dst_window  Please see
+         *                    https://gdal.org/api/raster_c_api.html?highlight=rasterio#_CPPv419GDALDatasetRasterIO12GDALDatasetH10GDALRWFlagiiiiPvii12GDALDataTypeiPiiii
          * @param band_number The band_number number of interest
          * @param type        The desired type of returned pixels (the argument is of
          *                    integral type GDALDataType)
          * @param data        The return-location of the read read data
-	 * @return The number of attempts made (upon success) or a
-	 *         negative error code (upon failure)
+         * @return The number of attempts made (upon success) or a negative error code
+         *         (upon failure)
          */
         public static native int get_data( /* */
                         long token, /* */
@@ -437,8 +438,8 @@ public class GDALWarp {
          * @param attempts  The number of attempts to make before giving up
          * @param transform The return location for the six double-precision floating
          *                  point number that will be returned
-	 * @return The number of attempts made (upon success) or a
-	 *         negative error code (upon failure)
+         * @return The number of attempts made (upon success) or a negative error code
+         *         (upon failure)
          */
         public static native int get_transform(long token, int dataset, int attempts, /* */
                         double[] transform);

--- a/src/unit_tests/dataset_tests.cpp
+++ b/src/unit_tests/dataset_tests.cpp
@@ -66,9 +66,8 @@ BOOST_AUTO_TEST_CASE(get_histogram)
     errno_init();
 
     GUIntBig panContainer[256];
-    ld.get_histogram(locked_dataset::SOURCE, 1, -0.5, 255.5, *&panContainer, true, false);
+    ld.get_histogram(locked_dataset::SOURCE, 1, -0.5, 255.5, 256, *&panContainer, true, false);
 
-    printf("Head of histogram is: %ld", (long int)panContainer[0]);
     BOOST_TEST(panContainer[0] == 3265829);
     BOOST_TEST(panContainer[12] == 487792);
 

--- a/src/unit_tests/dataset_tests.cpp
+++ b/src/unit_tests/dataset_tests.cpp
@@ -60,6 +60,21 @@ BOOST_AUTO_TEST_CASE(get_block_size)
     errno_deinit();
 }
 
+BOOST_AUTO_TEST_CASE(get_histogram)
+{
+    auto ld = locked_dataset(uri_options1);
+    errno_init();
+
+    GUIntBig panContainer[256];
+    ld.get_histogram(locked_dataset::SOURCE, 1, -0.5, 255.5, *&panContainer, true, false);
+
+    printf("Head of histogram is: %ld", (long int)panContainer[0]);
+    BOOST_TEST(panContainer[0] == 3265829);
+    BOOST_TEST(panContainer[12] == 487792);
+
+    errno_deinit();
+}
+
 BOOST_AUTO_TEST_CASE(get_offset)
 {
     auto ld = locked_dataset(uri_options1);


### PR DESCRIPTION
Overview
-----

This PR adds a binding for [`GetHistogram`](https://gdal.org/doxygen/classGDALRasterBand.html#aa21dcb3609bff012e8f217ebb7c81953).

Notes
-----

~There's [something](https://github.com/geotrellis/gdal-warp-bindings/pull/64/files#diff-b7fdb640c87d13512d13f895e2494172R196) I'm having trouble figuring out how to google (I know it's not supposed to work on pointers -- I had trouble even after realizing that that was an error). For some reason, I'm not getting the length of the array, after much googling about determining array length in c++ from a pointer to an array (sidenote: it's a comically bad ergonomic feature that this is difficult). However,~ I think it's basically set for you to look at it, since I've

- [x] killed the `nBuckets` argument in java to pass it from the array container length
- [x] added a unit test with expectations based on the test tif
- [x] fixed docstrings
- [x] cleaned up formatting based on what vscode said to do
- [x] made java var names not include c type hint conventions

Testing
-----

run tests