### PR TITLE
Update Build Environment

### DIFF
--- a/.travis/tests.sh
+++ b/.travis/tests.sh
@@ -5,15 +5,16 @@ ln -s /tmp/c41078a1.tif src/experiments/data/c41078a1.tif # sic
 docker run -it --rm \
       -v $(pwd):/workdir \
       -e CC=gcc -e CXX=g++ \
-      -e CFLAGS="-Wall -Werror -O0 -ggdb3 -DSO_FINI -D_GNU_SOURCE" \
+      -e CFLAGS="-Wall -Wno-sign-compare -Werror -O0 -ggdb3 -DSO_FINI -D_GNU_SOURCE" \
+      -e BOOST_ROOT="/usr/local/include/boost_1_69_0" \
       -e JAVA_HOME="/usr/lib/jvm/java-8-openjdk-amd64" \
-      jamesmcclain/gdal-build-environment:3 make -j4 -C src tests || exit -1
+      jamesmcclain/gdal-build-environment:4 make -j4 -C src tests || exit -1
 
 docker run -it --rm \
       -v $(pwd):/workdir \
       -e CC=gcc -e CXX=g++ \
       -e JAVA_HOME="/usr/lib/jvm/java-8-openjdk-amd64" \
-      jamesmcclain/gdal-build-environment:3 make -j4 -C src/experiments/thread pattern oversubscribe || exit -1
+      jamesmcclain/gdal-build-environment:4 make -j4 -C src/experiments/thread pattern oversubscribe || exit -1
 
 rm -f $(find | grep '\.o$')
 docker run -it --rm \
@@ -24,11 +25,11 @@ docker run -it --rm \
       -e CC=cc -e CXX=c++ \
       -e CFLAGS="-Wall -Werror -O0 -ggdb3" \
       -e JAVA_HOME="/macintosh/jdk8u202-b08/Contents/Home" \
-      -e GDALCFLAGS="-I/macintosh/gdal/2.4.0_1/include" \
+      -e GDALCFLAGS="-I/macintosh/gdal/2.4.2_3/include" \
       -e CXXFLAGS="-I/usr/osxcross/SDK/MacOSX10.10.sdk/usr/include/c++/v1"  \
       -e BOOST_ROOT="/usr/local/include/boost_1_69_0" \
-      -e LDFLAGS="-mmacosx-version-min=10.9 -L/macintosh/gdal/2.4.0_1/lib -lgdal -lstdc++ -lpthread" \
-      jamesmcclain/gdal-build-environment:3 make -j4 -C src libgdalwarp_bindings.dylib || exit -1
+      -e LDFLAGS="-mmacosx-version-min=10.9 -L/macintosh/gdal/2.4.2_3/lib -lgdal -lstdc++ -lpthread" \
+      jamesmcclain/gdal-build-environment:4 make -j4 -C src libgdalwarp_bindings.dylib || exit -1
 
 docker run -it --rm \
       -v $(pwd):/workdir \
@@ -36,9 +37,10 @@ docker run -it --rm \
       -e OS=win32 \
       -e CFLAGS="-Wall -Werror -Os -g" \
       -e JAVA_HOME="/windows/jdk8u202-b08" \
+      -e GDALCFLAGS="-I/usr/local/include" \
       -e BOOST_ROOT="/usr/local/include/boost_1_69_0" \
       -e LDFLAGS="-L/windows/gdal/lib -lgdal_i -lstdc++ -lpthread -lws2_32" \
-      jamesmcclain/gdal-build-environment:3 make -j4 -C src gdalwarp_bindings.dll || exit -1
+      jamesmcclain/gdal-build-environment:4 make -j4 -C src gdalwarp_bindings.dll || exit -1
 
 cp src/libgdalwarp_bindings.dylib src/main/java/resources/ || exit -1
 cp src/gdalwarp_bindings.dll src/main/java/resources/ || exit -1

--- a/Docker/Dockerfile.environment
+++ b/Docker/Dockerfile.environment
@@ -2,10 +2,19 @@ FROM jamesmcclain/crossbuild:0
 LABEL maintainer="James McClain <james.mcclain@gmail.com>"
 
 RUN apt-get update -q && \
-    apt-get install build-essential libgdal-dev openjdk-8-jdk -y -q && \
+    apt-get install build-essential pkg-config openjdk-8-jdk -y -q && \
     apt-get autoremove && \
     apt-get autoclean && \
     apt-get clean
+
+# Build GDAL 2.4.3
+RUN cd /usr/local/src && \
+    wget -k 'https://download.osgeo.org/gdal/2.4.3/gdal-2.4.3.tar.gz' && \
+    wget -k 'https://download.osgeo.org/proj/proj-4.9.3.tar.gz' && \
+    tar axvf gdal-2.4.3.tar.gz && tar axvf proj-4.9.3.tar.gz && \
+    cd proj-4.9.3 && ./configure --prefix=/usr/local && nice -n 19 make -j33 && make install && \
+    cd ../gdal-2.4.3 && ./configure --prefix=/usr/local && nice -n 19 make -j33 && make install && \
+    cd .. && rm -r proj-4.9.3/ gdal-2.4.3/ proj-4.9.3.tar.gz gdal-2.4.3.tar.gz
 
 # Test data
 RUN wget 'https://download.osgeo.org/geotiff/samples/usgs/c41078a1.tif' -k -O /tmp/c41078a1.tif
@@ -23,9 +32,9 @@ RUN mkdir -p /macintosh && \
     wget "https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u202-b08/OpenJDK8U-jdk_x64_mac_hotspot_8u202b08.tar.gz" && \
     tar axvf OpenJDK8U-jdk_x64_mac_hotspot_8u202b08.tar.gz && \
     rm -f OpenJDK8U-jdk_x64_mac_hotspot_8u202b08.tar.gz && \
-    wget "https://homebrew.bintray.com/bottles/gdal-2.4.0_1.sierra.bottle.tar.gz" && \
-    tar axvf gdal-2.4.0_1.sierra.bottle.tar.gz && \
-    rm -f gdal-2.4.0_1.sierra.bottle.tar.gz
+    wget "https://homebrew.bintray.com/bottles/gdal-2.4.2_3.high_sierra.bottle.tar.gz" && \
+    tar axvf gdal-2.4.2_3.high_sierra.bottle.tar.gz && \
+    rm -f gdal-2.4.2_3.high_sierra.bottle.tar.gz
 
 # Windows
 RUN mkdir -p /windows && \
@@ -35,8 +44,11 @@ RUN mkdir -p /windows && \
     rm -r OpenJDK8U-jdk_x64_windows_hotspot_8u202b08.zip && \
     mkdir -p /windows/gdal && \
     cd /windows/gdal && \
-    wget "http://download.gisinternals.com/sdk/downloads/release-1900-x64-gdal-2-4-0-mapserver-7-2-2-libs.zip" && \
-    unzip release-1900-x64-gdal-2-4-0-mapserver-7-2-2-libs.zip && \
-    rm -f release-1900-x64-gdal-2-4-0-mapserver-7-2-2-libs.zip
+    wget "http://download.gisinternals.com/sdk/downloads/release-1900-x64-gdal-2-4-3-mapserver-7-4-2-libs.zip" && \
+    unzip release-1900-x64-gdal-2-4-3-mapserver-7-4-2-libs.zip && \
+    rm -f release-1900-x64-gdal-2-4-3-mapserver-7-4-2-libs.zip
 
-# docker build -f Dockerfile.environment -t jamesmcclain/gdal-build-environment:3 .
+# Linkage
+RUN echo '/usr/local/lib' >> /etc/ld.so.conf && ldconfig
+
+# docker build -f Dockerfile.environment -t jamesmcclain/gdal-build-environment:4 .

--- a/README.md
+++ b/README.md
@@ -34,9 +34,11 @@ Please see [`src/main/java/com/azavea/gdal/GDALWarp.java`](src/main/java/com/aza
 
 # Binary Artifacts #
 
+## BinTray ##
+
 The binary artifacts are present on [Bintray](https://bintray.com/azavea/geotrellis/gdal-warp-bindings/_latestVersion).
 This jar file contains Linux, Macintosh, and Windows shared libraries.
-All native binaries are built for [AMD64](https://en.wikipedia.org/wiki/X86-64#AMD64); the Linux ones are linked against the Ubuntu 18.04 GDAL 2.2.3 package (`libgdal-dev`), The Macintosh ones are linked against [GDAL 2.4.0 from Homebrew](https://formulae.brew.sh/formula/gdal#default), and the Windows ones are linked against the [GDAL 2.4.0 MSVC 2015 build from GISinternals.com](http://www.gisinternals.com/release.php).
+All native binaries are built for [AMD64](https://en.wikipedia.org/wiki/X86-64#AMD64); the Linux ones are linked against GDAL 2.4.3, The Macintosh ones are linked against [GDAL 2.4.2 from Homebrew](https://formulae.brew.sh/formula/gdal#default), and the Windows ones are linked against the [GDAL 2.4.3 MSVC 2015 build from GISinternals.com](http://www.gisinternals.com/release.php).
 
 The class files in the jar were built with OpenJDK 8.
 
@@ -49,6 +51,11 @@ The jar file is reachable via Maven:
   <type>pom</type>
 </dependency>
 ```
+
+## SonaType ##
+
+The binary artifacts are also available on [SonaType](https://search.maven.org/artifact/com.azavea.geotrellis/gdal-warp-bindings).
+The set of artifacts available there is a subset of those on BinTray, but they are there for permanence and slightly easier access.
 
 # Repository Structure #
 


### PR DESCRIPTION
- The Linux build now uses GDAL 2.4.3
- The Macintosh build uses GDAL 2.4.2
- The Windows build now uses GDAL 2.4.3

Connects https://github.com/geotrellis/gdal-warp-bindings/pull/74

Todo:
   - [x] Update README