### PR TITLE
Fix locked_dataset::lock_for_deletion() function behavior

### DIFF
--- a/src/experiments/thread/pattern.cpp
+++ b/src/experiments/thread/pattern.cpp
@@ -42,7 +42,7 @@ char const *options[] = {
 #pragma GCC diagnostic pop
 
 // Constants
-constexpr int N = (1024);
+constexpr int N = 1024;
 constexpr int DIM = 1 << 8;
 constexpr int BUFFERSIZE = DIM * DIM;
 constexpr int ATTEMPTS = 1 << 20;
@@ -51,6 +51,9 @@ constexpr int COPIES = -4;
 // Threads
 int lg_steps = 12;
 pthread_t threads[N];
+
+// Cache size
+int cache_size = 1 << 8;
 
 // ANSI
 // Reference: https://stackoverflow.com/questions/3219393/stdlib-and-colored-output-in-c
@@ -123,10 +126,19 @@ int main(int argc, char **argv)
         }
         fprintf(stderr, ANSI_COLOR_BLUE "n = %d\n" ANSI_COLOR_RESET, n);
     }
+    if (argc >= 5)
+    {
+        sscanf(argv[4], "%d", &cache_size);
+        if (cache_size < 0)
+        {
+            cache_size = 1 << 8;
+        }
+        fprintf(stderr, ANSI_COLOR_BLUE "cache_size = %d\n" ANSI_COLOR_RESET, cache_size);
+    }
 
     // Setup
 
-    init(1 << 8);
+    init(cache_size);
     dup2(open("/dev/null", O_WRONLY), 2);
 
     for (int i = 0; i < n; ++i)

--- a/src/locked_dataset.hpp
+++ b/src/locked_dataset.hpp
@@ -632,7 +632,10 @@ public:
     bool lock_for_deletion()
     {
         // If the lock could not be obtained, return false
-        TRYLOCK
+        if (pthread_mutex_trylock(&m_dataset_lock) != 0)
+        {
+            return false;
+        }        
         // If the lock could be obtained but the reference count is
         // not zero, return false
         else if (m_use_count != 0)


### PR DESCRIPTION
In some cases lock_for_deletion could return true instead of false, that could lead to an inappropriate state in the LRU cache that could cause issues described in https://github.com/geotrellis/gdal-warp-bindings/issues/72. Actually @jamesmcclain noticed that in [this comment](https://github.com/geotrellis/gdal-warp-bindings/issues/72#issuecomment-576770452) and he was 💯 correct.

To reproduce the behaviour we'd need to spawn multiple threads for a small LRU cache; the `pattern` experiment was a bit modified (it is possible to set the LRU cache size now); to run the experiment do:

```bash
$ docker run -it --rm \
      -v $(pwd):/workdir \
      -e CC=gcc -e CXX=g++ \
      -e BOOST_ROOT="/usr/local/include/boost_1_69_0" \
      -e JAVA_HOME="/usr/lib/jvm/java-8-openjdk-amd64" \
      jamesmcclain/gdal-build-environment:4 bash

$ cd src/experiments/thread/
# 1 is the size of a cache below
$ ./pattern /tmp/c41078a1.tif 100 1000 1
# or if you want to try gdb 
# it can be useful if you want to see how many threads were spawned
# and that application is not in a deadlock
$ gdb pattern
$ run /tmp/c41078a1.tif 100 1000 1
```

The test should not fail (if it fails (without applying this fix) - it dies in a couple of seconds).

Closes https://github.com/geotrellis/gdal-warp-bindings/issues/72