### PR TITLE
Make get_pixels threadsafe

### DIFF
--- a/src/locked_dataset.hpp
+++ b/src/locked_dataset.hpp
@@ -568,9 +568,8 @@ public:
                    GDALDataType type,
                    void *data) const
     {
-        GDALRasterBandH band = GDALGetRasterBand(m_datasets[dataset], band_number);
-
         TRYLOCK
+        GDALRasterBandH band = GDALGetRasterBand(m_datasets[dataset], band_number);
         auto retval = GDALRasterIO(
             band,                         // source band
             GF_Read,                      // mode


### PR DESCRIPTION
This call should definitely be hidden under the TRYLOCK. 
However, I'm not sure that it is related https://github.com/locationtech/geotrellis/issues/3184; checking that.