### PR TITLE
Link MinGW statically

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,7 +70,7 @@ jobs:
       JAVA_HOME: "/windows/jdk8u202-b08"
       GDALCFLAGS: "-I/usr/local/include"
       BOOST_ROOT: "/usr/local/include/boost_1_69_0"
-      LDFLAGS: "-L/windows/gdal/lib -lgdal_i -lstdc++ -lpthread -lws2_32"
+      LDFLAGS: "-L/windows/gdal/lib -lgdal_i -static-libgcc -static-libstdc++ -Wl,-Bstatic -lstdc++ -lpthread -Wl,-Bdynamic -lws2_32"
       LD_LIBRARY_PATH: "/usr/x86_64-linux-gnu/x86_64-w64-mingw32/lib:"
       LD_LIBRARY_PATH_ORIGIN: ""
       CROSS_ROOT: /usr/x86_64-w64-mingw32

--- a/.circleci/deploy.sh
+++ b/.circleci/deploy.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [ ! -z "${GPG_KEY}" ] && [ ! -z "${CIRCLE_TAG}" ]
+if [ ! -z "${GPG_KEY}" ]
 then
   mkdir -p ~/.m2
   cp /workdir/.circleci/settings.xml ~/.m2/

--- a/README.md
+++ b/README.md
@@ -32,12 +32,13 @@ Please see [`src/bindings.h`](src/bindings.h) for the full C/C++ interface.
 
 Please see [`src/main/java/com/azavea/gdal/GDALWarp.java`](src/main/java/com/azavea/gdal/GDALWarp.java) for the full Java interface
 
-# Binary Artifacts #
+# SonaType Artifacts #
 
-## BinTray ##
+The binary artifacts are present on [SonaType](https://search.maven.org/artifact/com.azavea.geotrellis/gdal-warp-bindings).
+Snaphost artifacts are present on the [SonaType Snapshots repo](https://oss.sonatype.org/content/repositories/snapshots).
 
-The binary artifacts are present on [Bintray](https://bintray.com/azavea/geotrellis/gdal-warp-bindings/_latestVersion).
 This jar file contains Linux, Macintosh, and Windows shared libraries.
+
 All native binaries are built for [AMD64](https://en.wikipedia.org/wiki/X86-64#AMD64); the Linux ones are linked against GDAL 2.4.3, The Macintosh ones are linked against [GDAL 2.4.2 from Homebrew](https://formulae.brew.sh/formula/gdal#default), and the Windows ones are linked against the [GDAL 2.4.3 MSVC 2015 build from GISinternals.com](http://www.gisinternals.com/release.php).
 
 The class files in the jar were built with OpenJDK 8.
@@ -45,17 +46,12 @@ The class files in the jar were built with OpenJDK 8.
 The jar file is reachable via Maven:
 ```
 <dependency>
-  <groupId>com.azavea.gdal</groupId>
+  <groupId>com.azavea.geotrellis</groupId>
   <artifactId>gdal-warp-bindings</artifactId>
-  <version>33.xxxxxxx</version>
+  <version>x.x.x</version>
   <type>pom</type>
 </dependency>
 ```
-
-## SonaType ##
-
-The binary artifacts are also available on [SonaType](https://search.maven.org/artifact/com.azavea.geotrellis/gdal-warp-bindings).
-The set of artifacts available there is a subset of those on BinTray, but they are there for permanence and slightly easier access.
 
 # Repository Structure #
 
@@ -85,4 +81,4 @@ If one only wishes to use the C/C++ library, then type `OS=darwin SO=dylib make 
 ### Windows ###
 
 The Windows version has only been cross-built with [MinGW](http://www.mingw.org/wiki/InstallationHOWTOforMinGW) from within a Linux Docker container.
-Please see the [continuous integration script](.travis/tests.sh) for more.
+Please see the [test script](scripts/tests.sh) for more.

--- a/scripts/publish-local.sh
+++ b/scripts/publish-local.sh
@@ -39,7 +39,7 @@ docker run -it --rm \
       -e JAVA_HOME="/windows/jdk8u202-b08" \
       -e GDALCFLAGS="-I/usr/local/include" \
       -e BOOST_ROOT="/usr/local/include/boost_1_69_0" \
-      -e LDFLAGS="-L/windows/gdal/lib -lgdal_i -lstdc++ -lpthread -lws2_32" \
+      -e LDFLAGS="-L/windows/gdal/lib -lgdal_i -static-libgcc -static-libstdc++ -Wl,-Bstatic -lstdc++ -lpthread -Wl,-Bdynamic -lws2_32" \
       jamesmcclain/gdal-build-environment:4 make -j4 -C src gdalwarp_bindings.dll || exit -1
 
 rm -f src/main/resources/*.so

--- a/scripts/tests.sh
+++ b/scripts/tests.sh
@@ -39,7 +39,7 @@ docker run -it --rm \
       -e JAVA_HOME="/windows/jdk8u202-b08" \
       -e GDALCFLAGS="-I/usr/local/include" \
       -e BOOST_ROOT="/usr/local/include/boost_1_69_0" \
-      -e LDFLAGS="-L/windows/gdal/lib -lgdal_i -lstdc++ -lpthread -lws2_32" \
+      -e LDFLAGS="-L/windows/gdal/lib -lgdal_i -static-libgcc -static-libstdc++ -Wl,-Bstatic -lstdc++ -lpthread -Wl,-Bdynamic -lws2_32" \
       jamesmcclain/gdal-build-environment:4 make -j4 -C src gdalwarp_bindings.dll || exit -1
 
 rm -f src/main/resources/*.so


### PR DESCRIPTION
This PR links MinGW libs statically to make them finally work on Windows (this is suggested, checked and fixed by @echeipesh) and also updates the README.md file.

Closes https://github.com/geotrellis/gdal-warp-bindings/issues/88