### PR TITLE
GDAL 3.x Support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 executors:
   gdal-build-executor:
     docker:
-      - image: jamesmcclain/gdal-build-environment:4
+      - image: daunnc/gdal-build-environment:5
     working_directory: /workdir
 
 jobs:
@@ -41,10 +41,10 @@ jobs:
       CXX: c++
       CFLAGS: "-Wall -Werror -O0 -ggdb3"
       JAVA_HOME: "/macintosh/jdk8u202-b08/Contents/Home"
-      GDALCFLAGS: "-I/macintosh/gdal/2.4.2_3/include"
+      GDALCFLAGS: "-I/macintosh/gdal/3.1.2/include"
       CXXFLAGS: "-I/usr/osxcross/SDK/MacOSX10.10.sdk/usr/include/c++/v1"
       BOOST_ROOT: "/usr/local/include/boost_1_69_0"
-      LDFLAGS: "-mmacosx-version-min=10.9 -L/macintosh/gdal/2.4.2_3/lib -lgdal -lstdc++ -lpthread"
+      LDFLAGS: "-mmacosx-version-min=10.9 -L/macintosh/gdal/3.1.2/lib -lgdal -lstdc++ -lpthread"
       LD_LIBRARY_PATH_ORIGIN: ""
       CROSS_ROOT: /usr/x86_64-apple-darwin14
       PATH: /usr/x86_64-apple-darwin14/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 executors:
   gdal-build-executor:
     docker:
-      - image: daunnc/gdal-build-environment:5
+      - image: daunnc/gdal-build-environment:6
     working_directory: /workdir
 
 jobs:

--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,7 @@ README.html
 
 # VSCode files
 .vscode
+.history
 
 # Test data files #
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [v1.0.1]
+### Changed
+- GDAL 3.x Support [#96](https://github.com/geotrellis/gdal-warp-bindings/pull/96)
+
+## [v1.0.1] - 2020-04-22
 ### Fixed
 - Fix Empty Metadata retrieval [#93](https://github.com/geotrellis/gdal-warp-bindings/pull/93)
 
-## [v1.0.0]
+## [v1.0.0] - 2020-03-12
 ### Added
 - Option to disable log message colorization [#78](https://github.com/geotrellis/gdal-warp-bindings/issues/78)
 - Add a special error code for the max attempts acceded case [#83](https://github.com/geotrellis/gdal-warp-bindings/issues/83)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [v1.0.0] - 2020-03-12
 ### Added
 - Option to disable log message colorization [#78](https://github.com/geotrellis/gdal-warp-bindings/issues/78)
-- Add a special error code for the max attempts acceded case [#83](https://github.com/geotrellis/gdal-warp-bindings/issues/83)
+- Add a special error code for the max attempts exceeded case [#83](https://github.com/geotrellis/gdal-warp-bindings/issues/83)
 
 ### Fixed
 - Assertion failed on parallel reads [#72](https://github.com/geotrellis/gdal-warp-bindings/issues/72)

--- a/Docker/Dockerfile.environment
+++ b/Docker/Dockerfile.environment
@@ -1,20 +1,23 @@
 FROM jamesmcclain/crossbuild:0
 LABEL maintainer="James McClain <james.mcclain@gmail.com>"
 
-RUN apt-get update -q && \
+RUN apt-get update -y && \
     apt-get install build-essential pkg-config openjdk-8-jdk -y -q && \
     apt-get autoremove && \
     apt-get autoclean && \
     apt-get clean
 
-# Build GDAL 2.4.3
+# Install SQLite
+RUN apt-get install -y sqlite3 libsqlite3-dev
+
+# Build GDAL 3.1.2
 RUN cd /usr/local/src && \
-    wget -k 'https://download.osgeo.org/gdal/2.4.3/gdal-2.4.3.tar.gz' && \
-    wget -k 'https://download.osgeo.org/proj/proj-4.9.3.tar.gz' && \
-    tar axvf gdal-2.4.3.tar.gz && tar axvf proj-4.9.3.tar.gz && \
-    cd proj-4.9.3 && ./configure --prefix=/usr/local && nice -n 19 make -j33 && make install && \
-    cd ../gdal-2.4.3 && ./configure --prefix=/usr/local && nice -n 19 make -j33 && make install && \
-    cd .. && rm -r proj-4.9.3/ gdal-2.4.3/ proj-4.9.3.tar.gz gdal-2.4.3.tar.gz
+    wget -k 'https://download.osgeo.org/gdal/3.1.2/gdal-3.1.2.tar.gz' && \
+    wget -k 'https://download.osgeo.org/proj/proj-6.0.0.tar.gz' && \
+    tar axvf gdal-3.1.2.tar.gz && tar axvf proj-6.0.0.tar.gz && \
+    cd proj-6.0.0 && ./configure --prefix=/usr/local && nice -n 19 make -j33 && make install && \
+    cd ../gdal-3.1.2 && ./configure --prefix=/usr/local && nice -n 19 make -j33 && make install && \
+    cd .. && rm -r proj-6.0.0/ gdal-3.1.2/ proj-6.0.0.tar.gz gdal-3.1.2.tar.gz
 
 # Test data
 RUN wget 'https://download.osgeo.org/geotiff/samples/usgs/c41078a1.tif' -k -O /tmp/c41078a1.tif
@@ -32,9 +35,10 @@ RUN mkdir -p /macintosh && \
     wget "https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u202-b08/OpenJDK8U-jdk_x64_mac_hotspot_8u202b08.tar.gz" && \
     tar axvf OpenJDK8U-jdk_x64_mac_hotspot_8u202b08.tar.gz && \
     rm -f OpenJDK8U-jdk_x64_mac_hotspot_8u202b08.tar.gz && \
-    wget "https://homebrew.bintray.com/bottles/gdal-2.4.2_3.high_sierra.bottle.tar.gz" && \
-    tar axvf gdal-2.4.2_3.high_sierra.bottle.tar.gz && \
-    rm -f gdal-2.4.2_3.high_sierra.bottle.tar.gz
+    wget "http://homebrew.bintray.com/bottles/gdal-3.1.2.high_sierra.bottle.tar.gz" && \
+    tar axvf gdal-3.1.2.high_sierra.bottle.tar.gz && \
+    rm -f gdal-3.1.2.high_sierra.bottle.tar.gz
+
 
 # Windows
 RUN mkdir -p /windows && \
@@ -44,9 +48,9 @@ RUN mkdir -p /windows && \
     rm -r OpenJDK8U-jdk_x64_windows_hotspot_8u202b08.zip && \
     mkdir -p /windows/gdal && \
     cd /windows/gdal && \
-    wget "http://download.gisinternals.com/sdk/downloads/release-1900-x64-gdal-2-4-3-mapserver-7-4-2-libs.zip" && \
-    unzip release-1900-x64-gdal-2-4-3-mapserver-7-4-2-libs.zip && \
-    rm -f release-1900-x64-gdal-2-4-3-mapserver-7-4-2-libs.zip
+    wget "http://download.gisinternals.com/sdk/downloads/release-1911-x64-gdal-3-0-4-mapserver-7-4-3-libs.zip" && \
+    unzip release-1911-x64-gdal-3-0-4-mapserver-7-4-3-libs.zip && \
+    rm -f release-1911-x64-gdal-3-0-4-mapserver-7-4-3-libs.zip
 
 # Linkage
 RUN echo '/usr/local/lib' >> /etc/ld.so.conf && ldconfig

--- a/Docker/Dockerfile.environment
+++ b/Docker/Dockerfile.environment
@@ -13,11 +13,15 @@ RUN apt-get install -y sqlite3 libsqlite3-dev
 # Build GDAL 3.1.2
 RUN cd /usr/local/src && \
     wget -k 'https://download.osgeo.org/gdal/3.1.2/gdal-3.1.2.tar.gz' && \
-    wget -k 'https://download.osgeo.org/proj/proj-6.0.0.tar.gz' && \
-    tar axvf gdal-3.1.2.tar.gz && tar axvf proj-6.0.0.tar.gz && \
-    cd proj-6.0.0 && ./configure --prefix=/usr/local && nice -n 19 make -j33 && make install && \
+    wget -k 'https://download.osgeo.org/proj/proj-7.1.0.tar.gz' && \
+    wget -k 'https://download.osgeo.org/libtiff/tiff-4.1.0.tar.gz' && \
+    wget -k 'https://curl.haxx.se/download/curl-7.71.1.tar.gz' && \
+    tar axvf gdal-3.1.2.tar.gz && tar axvf proj-7.1.0.tar.gz && tar axvf tiff-4.1.0.tar.gz && tar axvf curl-7.71.1.tar.gz && \
+    cd curl-7.71.1 && ./configure --prefix=/usr/local && nice -n 19 make -j33 && make install && \
+    cd ../tiff-4.1.0 && ./configure --prefix=/usr/local && nice -n 19 make -j33 && make install && \
+    cd ../proj-7.1.0 && ./configure --prefix=/usr/local && nice -n 19 make -j33 && make install && \
     cd ../gdal-3.1.2 && ./configure --prefix=/usr/local && nice -n 19 make -j33 && make install && \
-    cd .. && rm -r proj-6.0.0/ gdal-3.1.2/ proj-6.0.0.tar.gz gdal-3.1.2.tar.gz
+    cd .. && rm -r curl-7.71.1/ tiff-4.1.0/ proj-7.1.0/ gdal-3.1.2/ curl-7.71.1.tar.gz tiff-4.1.0.tar.gz proj-7.1.0.tar.gz gdal-3.1.2.tar.gz
 
 # Test data
 RUN wget 'https://download.osgeo.org/geotiff/samples/usgs/c41078a1.tif' -k -O /tmp/c41078a1.tif
@@ -55,4 +59,4 @@ RUN mkdir -p /windows && \
 # Linkage
 RUN echo '/usr/local/lib' >> /etc/ld.so.conf && ldconfig
 
-# docker build -f Dockerfile.environment -t jamesmcclain/gdal-build-environment:4 .
+# docker build -f Dockerfile.environment -t jamesmcclain/gdal-build-environment:6 .

--- a/scripts/publish-local.sh
+++ b/scripts/publish-local.sh
@@ -8,13 +8,13 @@ docker run -it --rm \
       -e CFLAGS="-Wall -Wno-sign-compare -Werror -O0 -ggdb3 -DSO_FINI -D_GNU_SOURCE" \
       -e BOOST_ROOT="/usr/local/include/boost_1_69_0" \
       -e JAVA_HOME="/usr/lib/jvm/java-8-openjdk-amd64" \
-      jamesmcclain/gdal-build-environment:4 make -j4 -C src tests || exit -1
+      daunnc/gdal-build-environment:5 make -j4 -C src tests || exit -1
 
 docker run -it --rm \
       -v $(pwd):/workdir \
       -e CC=gcc -e CXX=g++ \
       -e JAVA_HOME="/usr/lib/jvm/java-8-openjdk-amd64" \
-      jamesmcclain/gdal-build-environment:4 make -j4 -C src/experiments/thread pattern oversubscribe || exit -1
+      daunnc/gdal-build-environment:5 make -j4 -C src/experiments/thread pattern oversubscribe || exit -1
 
 rm -f $(find | grep '\.o$')
 docker run -it --rm \
@@ -25,11 +25,11 @@ docker run -it --rm \
       -e CC=cc -e CXX=c++ \
       -e CFLAGS="-Wall -Werror -O0 -ggdb3" \
       -e JAVA_HOME="/macintosh/jdk8u202-b08/Contents/Home" \
-      -e GDALCFLAGS="-I/macintosh/gdal/2.4.2_3/include" \
+      -e GDALCFLAGS="-I/macintosh/gdal/3.1.2/include" \
       -e CXXFLAGS="-I/usr/osxcross/SDK/MacOSX10.10.sdk/usr/include/c++/v1"  \
       -e BOOST_ROOT="/usr/local/include/boost_1_69_0" \
-      -e LDFLAGS="-mmacosx-version-min=10.9 -L/macintosh/gdal/2.4.2_3/lib -lgdal -lstdc++ -lpthread" \
-      jamesmcclain/gdal-build-environment:4 make -j4 -C src libgdalwarp_bindings.dylib || exit -1
+      -e LDFLAGS="-mmacosx-version-min=10.9 -L/macintosh/gdal/3.1.2/lib -lgdal -lstdc++ -lpthread" \
+      daunnc/gdal-build-environment:5 make -j4 -C src libgdalwarp_bindings.dylib || exit -1
 
 docker run -it --rm \
       -v $(pwd):/workdir \
@@ -40,7 +40,7 @@ docker run -it --rm \
       -e GDALCFLAGS="-I/usr/local/include" \
       -e BOOST_ROOT="/usr/local/include/boost_1_69_0" \
       -e LDFLAGS="-L/windows/gdal/lib -lgdal_i -static-libgcc -static-libstdc++ -Wl,-Bstatic -lstdc++ -lpthread -Wl,-Bdynamic -lws2_32" \
-      jamesmcclain/gdal-build-environment:4 make -j4 -C src gdalwarp_bindings.dll || exit -1
+      daunnc/gdal-build-environment:5 make -j4 -C src gdalwarp_bindings.dll || exit -1
 
 rm -f src/main/resources/*.so
 mv src/libgdalwarp_bindings.so src/main/resources/resources/

--- a/scripts/publish-local.sh
+++ b/scripts/publish-local.sh
@@ -8,13 +8,13 @@ docker run -it --rm \
       -e CFLAGS="-Wall -Wno-sign-compare -Werror -O0 -ggdb3 -DSO_FINI -D_GNU_SOURCE" \
       -e BOOST_ROOT="/usr/local/include/boost_1_69_0" \
       -e JAVA_HOME="/usr/lib/jvm/java-8-openjdk-amd64" \
-      daunnc/gdal-build-environment:5 make -j4 -C src tests || exit -1
+      daunnc/gdal-build-environment:6 make -j4 -C src tests || exit -1
 
 docker run -it --rm \
       -v $(pwd):/workdir \
       -e CC=gcc -e CXX=g++ \
       -e JAVA_HOME="/usr/lib/jvm/java-8-openjdk-amd64" \
-      daunnc/gdal-build-environment:5 make -j4 -C src/experiments/thread pattern oversubscribe || exit -1
+      daunnc/gdal-build-environment:6 make -j4 -C src/experiments/thread pattern oversubscribe || exit -1
 
 rm -f $(find | grep '\.o$')
 docker run -it --rm \
@@ -29,7 +29,7 @@ docker run -it --rm \
       -e CXXFLAGS="-I/usr/osxcross/SDK/MacOSX10.10.sdk/usr/include/c++/v1"  \
       -e BOOST_ROOT="/usr/local/include/boost_1_69_0" \
       -e LDFLAGS="-mmacosx-version-min=10.9 -L/macintosh/gdal/3.1.2/lib -lgdal -lstdc++ -lpthread" \
-      daunnc/gdal-build-environment:5 make -j4 -C src libgdalwarp_bindings.dylib || exit -1
+      daunnc/gdal-build-environment:6 make -j4 -C src libgdalwarp_bindings.dylib || exit -1
 
 docker run -it --rm \
       -v $(pwd):/workdir \
@@ -40,7 +40,7 @@ docker run -it --rm \
       -e GDALCFLAGS="-I/usr/local/include" \
       -e BOOST_ROOT="/usr/local/include/boost_1_69_0" \
       -e LDFLAGS="-L/windows/gdal/lib -lgdal_i -static-libgcc -static-libstdc++ -Wl,-Bstatic -lstdc++ -lpthread -Wl,-Bdynamic -lws2_32" \
-      daunnc/gdal-build-environment:5 make -j4 -C src gdalwarp_bindings.dll || exit -1
+      daunnc/gdal-build-environment:6 make -j4 -C src gdalwarp_bindings.dll || exit -1
 
 rm -f src/main/resources/*.so
 mv src/libgdalwarp_bindings.so src/main/resources/resources/

--- a/scripts/publish-local.sh
+++ b/scripts/publish-local.sh
@@ -16,7 +16,7 @@ docker run -it --rm \
       -e JAVA_HOME="/usr/lib/jvm/java-8-openjdk-amd64" \
       daunnc/gdal-build-environment:6 make -j4 -C src/experiments/thread pattern oversubscribe || exit -1
 
-rm -f $(find | grep '\.o$')
+rm -f $(find ./src | grep '\.o$')
 docker run -it --rm \
       -v $(pwd):/workdir \
       -e OSXCROSS_NO_INCLUDE_PATH_WARNINGS=1 \

--- a/scripts/tests.sh
+++ b/scripts/tests.sh
@@ -8,13 +8,13 @@ docker run -it --rm \
       -e CFLAGS="-Wall -Wno-sign-compare -Werror -O0 -ggdb3 -DSO_FINI -D_GNU_SOURCE" \
       -e BOOST_ROOT="/usr/local/include/boost_1_69_0" \
       -e JAVA_HOME="/usr/lib/jvm/java-8-openjdk-amd64" \
-      jamesmcclain/gdal-build-environment:4 make -j4 -C src tests || exit -1
+      daunnc/gdal-build-environment:5 make -j4 -C src tests || exit -1
 
 docker run -it --rm \
       -v $(pwd):/workdir \
       -e CC=gcc -e CXX=g++ \
       -e JAVA_HOME="/usr/lib/jvm/java-8-openjdk-amd64" \
-      jamesmcclain/gdal-build-environment:4 make -j4 -C src/experiments/thread pattern oversubscribe || exit -1
+      daunnc/gdal-build-environment:5 make -j4 -C src/experiments/thread pattern oversubscribe || exit -1
 
 rm -f $(find | grep '\.o$')
 docker run -it --rm \
@@ -25,11 +25,11 @@ docker run -it --rm \
       -e CC=cc -e CXX=c++ \
       -e CFLAGS="-Wall -Werror -O0 -ggdb3" \
       -e JAVA_HOME="/macintosh/jdk8u202-b08/Contents/Home" \
-      -e GDALCFLAGS="-I/macintosh/gdal/2.4.2_3/include" \
+      -e GDALCFLAGS="-I/macintosh/gdal/3.1.2/include" \
       -e CXXFLAGS="-I/usr/osxcross/SDK/MacOSX10.10.sdk/usr/include/c++/v1"  \
       -e BOOST_ROOT="/usr/local/include/boost_1_69_0" \
-      -e LDFLAGS="-mmacosx-version-min=10.9 -L/macintosh/gdal/2.4.2_3/lib -lgdal -lstdc++ -lpthread" \
-      jamesmcclain/gdal-build-environment:4 make -j4 -C src libgdalwarp_bindings.dylib || exit -1
+      -e LDFLAGS="-mmacosx-version-min=10.9 -L/macintosh/gdal/3.1.2/lib -lgdal -lstdc++ -lpthread" \
+      daunnc/gdal-build-environment:5 make -j4 -C src libgdalwarp_bindings.dylib || exit -1
 
 docker run -it --rm \
       -v $(pwd):/workdir \
@@ -40,7 +40,7 @@ docker run -it --rm \
       -e GDALCFLAGS="-I/usr/local/include" \
       -e BOOST_ROOT="/usr/local/include/boost_1_69_0" \
       -e LDFLAGS="-L/windows/gdal/lib -lgdal_i -static-libgcc -static-libstdc++ -Wl,-Bstatic -lstdc++ -lpthread -Wl,-Bdynamic -lws2_32" \
-      jamesmcclain/gdal-build-environment:4 make -j4 -C src gdalwarp_bindings.dll || exit -1
+      daunnc/gdal-build-environment:5 make -j4 -C src gdalwarp_bindings.dll || exit -1
 
 rm -f src/main/resources/*.so
 mv src/libgdalwarp_bindings.so src/main/resources/resources/

--- a/scripts/tests.sh
+++ b/scripts/tests.sh
@@ -8,13 +8,13 @@ docker run -it --rm \
       -e CFLAGS="-Wall -Wno-sign-compare -Werror -O0 -ggdb3 -DSO_FINI -D_GNU_SOURCE" \
       -e BOOST_ROOT="/usr/local/include/boost_1_69_0" \
       -e JAVA_HOME="/usr/lib/jvm/java-8-openjdk-amd64" \
-      daunnc/gdal-build-environment:5 make -j4 -C src tests || exit -1
+      daunnc/gdal-build-environment:6 make -j4 -C src tests || exit -1
 
 docker run -it --rm \
       -v $(pwd):/workdir \
       -e CC=gcc -e CXX=g++ \
       -e JAVA_HOME="/usr/lib/jvm/java-8-openjdk-amd64" \
-      daunnc/gdal-build-environment:5 make -j4 -C src/experiments/thread pattern oversubscribe || exit -1
+      daunnc/gdal-build-environment:6 make -j4 -C src/experiments/thread pattern oversubscribe || exit -1
 
 rm -f $(find | grep '\.o$')
 docker run -it --rm \
@@ -29,7 +29,7 @@ docker run -it --rm \
       -e CXXFLAGS="-I/usr/osxcross/SDK/MacOSX10.10.sdk/usr/include/c++/v1"  \
       -e BOOST_ROOT="/usr/local/include/boost_1_69_0" \
       -e LDFLAGS="-mmacosx-version-min=10.9 -L/macintosh/gdal/3.1.2/lib -lgdal -lstdc++ -lpthread" \
-      daunnc/gdal-build-environment:5 make -j4 -C src libgdalwarp_bindings.dylib || exit -1
+      daunnc/gdal-build-environment:6 make -j4 -C src libgdalwarp_bindings.dylib || exit -1
 
 docker run -it --rm \
       -v $(pwd):/workdir \
@@ -40,7 +40,7 @@ docker run -it --rm \
       -e GDALCFLAGS="-I/usr/local/include" \
       -e BOOST_ROOT="/usr/local/include/boost_1_69_0" \
       -e LDFLAGS="-L/windows/gdal/lib -lgdal_i -static-libgcc -static-libstdc++ -Wl,-Bstatic -lstdc++ -lpthread -Wl,-Bdynamic -lws2_32" \
-      daunnc/gdal-build-environment:5 make -j4 -C src gdalwarp_bindings.dll || exit -1
+      daunnc/gdal-build-environment:6 make -j4 -C src gdalwarp_bindings.dll || exit -1
 
 rm -f src/main/resources/*.so
 mv src/libgdalwarp_bindings.so src/main/resources/resources/

--- a/src/unit_tests/dataset_tests.cpp
+++ b/src/unit_tests/dataset_tests.cpp
@@ -116,6 +116,7 @@ BOOST_AUTO_TEST_CASE(get_offset)
     // - https://github.com/OSGeo/gdal/commit/69f25f253d141faf836c400676f9f94dd3f43707
     // 
     // BOOST_TEST(success != false);
+    BOOST_TEST(success == false);
     success = false;
 
     ld.get_offset(locked_dataset::WARPED, 1, &offset, &success);
@@ -167,6 +168,7 @@ BOOST_AUTO_TEST_CASE(get_scale)
     // - https://github.com/OSGeo/gdal/commit/69f25f253d141faf836c400676f9f94dd3f43707
     // 
     // BOOST_TEST(success != false);
+    BOOST_TEST(success == false);
     success = false;
 
     ld.get_scale(locked_dataset::WARPED, 1, &scale, &success);

--- a/src/unit_tests/dataset_tests.cpp
+++ b/src/unit_tests/dataset_tests.cpp
@@ -84,7 +84,7 @@ BOOST_AUTO_TEST_CASE(get_offset)
 
     ld.get_offset(locked_dataset::SOURCE, 1, &offset, &success);
     BOOST_TEST(offset == 0);
-    BOOST_TEST(success != false);
+    // BOOST_TEST(success != false);
     success = false;
 
     ld.get_offset(locked_dataset::WARPED, 1, &offset, &success);
@@ -104,7 +104,7 @@ BOOST_AUTO_TEST_CASE(get_scale)
 
     ld.get_scale(locked_dataset::SOURCE, 1, &scale, &success);
     BOOST_TEST(scale == 1);
-    BOOST_TEST(success != false);
+    // BOOST_TEST(success != false);
     success = false;
 
     ld.get_scale(locked_dataset::WARPED, 1, &scale, &success);

--- a/src/unit_tests/dataset_tests.cpp
+++ b/src/unit_tests/dataset_tests.cpp
@@ -84,6 +84,37 @@ BOOST_AUTO_TEST_CASE(get_offset)
 
     ld.get_offset(locked_dataset::SOURCE, 1, &offset, &success);
     BOOST_TEST(offset == 0);
+    // In GDAL 3.1 there happened a behavior change
+    // Both GetScale and GetOffset functions are affected.
+    // In the test raster Scale and Offset are not set and in GDAL 2.x and 3.0.x this case is handled differently.
+    //
+    // The root of the change:
+    // Even though Offset and Scale values were not set, there was a logic that fixed it and set values to 1.0 and 0.0 in GDAL 2.x and GDAL 3.0.x.
+    // The change in the references changes the success flag behavior, so on the Python side 
+    // it is possible to interpret the return results as None.
+    //
+    // It is easy to check it with the following python code:
+    // import gdal
+    // path = /tmp/c41078a1.tif
+    // ds = gdal.Open(path)
+    // band = ds.GetRasterBand(1)
+    // s = band.GetScale() # prints 1.0 in GDAL 2.x and 3.0.x, and None in GDAL 3.1.x
+    // o = band.GetOffset() # prints 0.0 in GDAL 2.x and 3.0.x, and None in GDAL 3.1.x
+    // 
+    // However, the Warp operation peformed in this test sets Scale and Offset values explicitly.
+    // It explains why the old test case with the Warped dataset didn't change its behavior.
+    // 
+    // It is easy to check it with the following python code:
+    // w = gdal.Warp('', path, format='MEM', warpOptions=["-r", "bilinear", "-t_srs", "epsg:3857", "-co", "BLOCKXSIZE=512", "-co", "BLOCKYSIZE=512"])
+    // wband = w.GetRasterBand(1)
+    // ws = wband.GetScale() # prints 1.0 in GDAL 2.x, 3.0.x, and GDAL 3.1.x
+    // wo = wband.GetOffset() # prints 0.0 in GDAL 2.x, 3.0.x, and GDAL 3.1.x
+    //
+    // References:
+    // - https://github.com/geotrellis/gdal-warp-bindings/pull/96 (PR that introduced this comment)
+    // - https://github.com/OSGeo/gdal/issues/2579
+    // - https://github.com/OSGeo/gdal/commit/69f25f253d141faf836c400676f9f94dd3f43707
+    // 
     // BOOST_TEST(success != false);
     success = false;
 
@@ -104,6 +135,37 @@ BOOST_AUTO_TEST_CASE(get_scale)
 
     ld.get_scale(locked_dataset::SOURCE, 1, &scale, &success);
     BOOST_TEST(scale == 1);
+    // In GDAL 3.1 there happened a behavior change
+    // Both GetScale and GetOffset functions are affected.
+    // In the test raster Scale and Offset are not set and in GDAL 2.x and 3.0.x this case is handled differently.
+    // 
+    // The root of the change:
+    // Even though Offset and Scale values were not set, there was a logic that fixed it and set values to 1.0 and 0.0 in GDAL 2.x and GDAL 3.0.x.
+    // The change in the references changes the success flag behavior, so on the Python side 
+    // it is possible to interpret the return results as None.
+    // 
+    // It is easy to check it with the following python code:
+    // import gdal
+    // path = /tmp/c41078a1.tif
+    // ds = gdal.Open(path)
+    // band = ds.GetRasterBand(1)
+    // s = band.GetScale() // prints 1.0 in GDAL 2.x and 3.0.x and None in GDAL 3.1.x
+    // o = band.GetOffset() // prints 0.0 in GDAL 2.x and 3.0.x and None in GDAL 3.1.x
+    // 
+    // However, the Warp operation peformed in this test sets Scale and Offset values explicitly.
+    // It explains why the old test case with the Warped dataset didn't change its behavior.
+    // 
+    // It is easy to check it with the following python code:
+    // w = gdal.Warp('', path, format='MEM', warpOptions=["-r", "bilinear", "-t_srs", "epsg:3857", "-co", "BLOCKXSIZE=512", "-co", "BLOCKYSIZE=512"])
+    // wband = w.GetRasterBand(1)
+    // ws = wband.GetScale() // prints 1.0 in GDAL 2.x, 3.0.x and GDAL 3.1.x
+    // wo = wband.GetOffset() // prints 0.0 in GDAL 2.x, 3.0.x and GDAL 3.1.x
+    //
+    // References:
+    // - https://github.com/geotrellis/gdal-warp-bindings/pull/96 (PR that introduced this comment)
+    // - https://github.com/OSGeo/gdal/issues/2579
+    // - https://github.com/OSGeo/gdal/commit/69f25f253d141faf836c400676f9f94dd3f43707
+    // 
     // BOOST_TEST(success != false);
     success = false;
 


### PR DESCRIPTION
In GDAL 3.1 there happened a behavior change. Both GetScale and GetOffset functions are affected.

In the test raster Scale and Offset are not set and in GDAL 2.x and 3.0.x this case is handled differently.

_The root of the change:_
Even though Offset and Scale values were not set, there was a logic that fixed it and set values to 1.0 and 0.0 in GDAL 2.x and GDAL 3.0.x.

The change in the references changes the success flag behavior, so on the Python side it is possible to interpret the return results as None. It is easy to check it with the following python code:

```python
import gdal

path = /tmp/c41078a1.tif
ds = gdal.Open(path)
band = ds.GetRasterBand(1)
s = band.GetScale() # prints 1.0 in GDAL 2.x and 3.0.x, and None in GDAL 3.1.x
o = band.GetOffset() # prints 0.0 in GDAL 2.x and 3.0.x, and None in GDAL 3.1.x
``` 

However, the Warp operation peformed in this test sets Scale and Offset values explicitly. It explains why the old test case with the Warped dataset didn't change its behavior. It is easy to check it with the following python code:

```python
import gdal

path = /tmp/c41078a1.tif
w = gdal.Warp('', path, format='MEM', warpOptions=["-r", "bilinear", "-t_srs", "epsg:3857", "-co", "BLOCKXSIZE=512", "-co", "BLOCKYSIZE=512"])
wband = w.GetRasterBand(1)
ws = wband.GetScale() # prints 1.0 in GDAL 2.x, 3.0.x, and GDAL 3.1.x
wo = wband.GetOffset() # prints 0.0 in GDAL 2.x, 3.0.x, and GDAL 3.1.x
```
References:
* https://github.com/OSGeo/gdal/issues/2579
* https://github.com/OSGeo/gdal/commit/69f25f253d141faf836c400676f9f94dd3f43707