### PR TITLE
Resolve MacOS dylib loading issues for gdal-warp-bindings

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ jobs:
       GDALCFLAGS: "-I/macintosh/gdal/3.1.2/include"
       CXXFLAGS: "-I/usr/osxcross/SDK/MacOSX10.10.sdk/usr/include/c++/v1"
       BOOST_ROOT: "/usr/local/include/boost_1_69_0"
-      LDFLAGS: "-mmacosx-version-min=10.9 -L/macintosh/gdal/3.1.2/lib -lgdal -lstdc++ -lpthread"
+      LDFLAGS: "-mmacosx-version-min=10.9 -L/macintosh/gdal/3.1.2/lib -lgdal -lstdc++ -lpthread -Wl,-rpath,/usr/local/lib"
       LD_LIBRARY_PATH_ORIGIN: ""
       CROSS_ROOT: /usr/x86_64-apple-darwin14
       PATH: /usr/x86_64-apple-darwin14/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 executors:
   gdal-build-executor:
     docker:
-      - image: quay.io/quay.io/geotrellis/gdal-warp-bindings-environment:1
+      - image: quay.io/geotrellis/gdal-warp-bindings-environment:1
     working_directory: /workdir
 
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 executors:
   gdal-build-executor:
     docker:
-      - image: daunnc/gdal-build-environment:6
+      - image: daunnc/gdal-build-environment:7
     working_directory: /workdir
 
 jobs:
@@ -37,7 +37,7 @@ jobs:
       CROSS_TRIPLE: x86_64-apple-darwin14
       OS: darwin
       SO: dylib
-      CC: cc 
+      CC: cc
       CXX: c++
       CFLAGS: "-Wall -Werror -O0 -ggdb3"
       JAVA_HOME: "/macintosh/jdk8u202-b08/Contents/Home"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 executors:
   gdal-build-executor:
     docker:
-      - image: daunnc/gdal-build-environment:7
+      - image: quay.io/geotrellis/gdal-warp-bindings-build:1
     working_directory: /workdir
 
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 executors:
   gdal-build-executor:
     docker:
-      - image: quay.io/geotrellis/gdal-warp-bindings-build:1
+      - image: quay.io/quay.io/geotrellis/gdal-warp-bindings-environment:1
     working_directory: /workdir
 
 jobs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Use Conda GDAL in MacOS to fix dylib load errors [#99](https://github.com/geotrellis/gdal-warp-bindings/pull/99). See the MacOS installation section of the README for more details.
+
 ## [v1.1.0] - 2020-08-10
 ### Changed
 - GDAL 3.x Support [#96](https://github.com/geotrellis/gdal-warp-bindings/pull/96)

--- a/Docker/Dockerfile.crossbuild
+++ b/Docker/Dockerfile.crossbuild
@@ -99,4 +99,4 @@ WORKDIR /workdir
 RUN wget -k 'https://raw.githubusercontent.com/multiarch/crossbuild/master/assets/crossbuild' -O /usr/bin/crossbuild && \
     chmod ugo+x /usr/bin/crossbuild
 
-# docker build -f Dockerfile.crossbuild -t jamesmcclain/crossbuild:0 .
+# docker build -f Dockerfile.crossbuild -t quay.io/geotrellis/gdal-warp-bindings-crossbuild:latest .

--- a/Docker/Dockerfile.environment
+++ b/Docker/Dockerfile.environment
@@ -39,10 +39,10 @@ RUN mkdir -p /macintosh && \
     wget "https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u202-b08/OpenJDK8U-jdk_x64_mac_hotspot_8u202b08.tar.gz" && \
     tar axvf OpenJDK8U-jdk_x64_mac_hotspot_8u202b08.tar.gz && \
     rm -f OpenJDK8U-jdk_x64_mac_hotspot_8u202b08.tar.gz && \
-    wget "http://homebrew.bintray.com/bottles/gdal-3.1.2.high_sierra.bottle.tar.gz" && \
-    tar axvf gdal-3.1.2.high_sierra.bottle.tar.gz && \
-    rm -f gdal-3.1.2.high_sierra.bottle.tar.gz
-
+    wget "https://anaconda.org/conda-forge/libgdal/3.1.2/download/osx-64/libgdal-3.1.2-hd7bf8dc_4.tar.bz2" && \
+    mkdir -p gdal/3.1.2 && \
+    tar axvf libgdal-3.1.2-hd7bf8dc_4.tar.bz2 -C gdal/3.1.2 && \
+    rm -f libgdal-3.1.2-hd7bf8dc_4.tar.bz2
 
 # Windows
 RUN mkdir -p /windows && \

--- a/Docker/Dockerfile.environment
+++ b/Docker/Dockerfile.environment
@@ -59,4 +59,4 @@ RUN mkdir -p /windows && \
 # Linkage
 RUN echo '/usr/local/lib' >> /etc/ld.so.conf && ldconfig
 
-# docker build -f Dockerfile.environment -t daunnc/gdal-build-environment:7 .
+# docker build -f Dockerfile.environment -t quay.io/geotrellis/gdal-warp-bindings-build:1 .

--- a/Docker/Dockerfile.environment
+++ b/Docker/Dockerfile.environment
@@ -1,5 +1,5 @@
-FROM jamesmcclain/crossbuild:0
-LABEL maintainer="James McClain <james.mcclain@gmail.com>"
+FROM quay.io/geotrellis/gdal-warp-bindings-crossbuild:1
+LABEL maintainer="Azavea <info@azavea.com>"
 
 RUN apt-get update -y && \
     apt-get install build-essential pkg-config openjdk-8-jdk -y -q && \
@@ -59,4 +59,4 @@ RUN mkdir -p /windows && \
 # Linkage
 RUN echo '/usr/local/lib' >> /etc/ld.so.conf && ldconfig
 
-# docker build -f Dockerfile.environment -t quay.io/quay.io/geotrellis/gdal-warp-bindings-environment:1 .
+# docker build -f Dockerfile.environment -t quay.io/geotrellis/gdal-warp-bindings-environment:latest .

--- a/Docker/Dockerfile.environment
+++ b/Docker/Dockerfile.environment
@@ -59,4 +59,4 @@ RUN mkdir -p /windows && \
 # Linkage
 RUN echo '/usr/local/lib' >> /etc/ld.so.conf && ldconfig
 
-# docker build -f Dockerfile.environment -t quay.io/geotrellis/gdal-warp-bindings-build:1 .
+# docker build -f Dockerfile.environment -t quay.io/quay.io/geotrellis/gdal-warp-bindings-environment:1 .

--- a/Docker/Dockerfile.environment
+++ b/Docker/Dockerfile.environment
@@ -59,4 +59,4 @@ RUN mkdir -p /windows && \
 # Linkage
 RUN echo '/usr/local/lib' >> /etc/ld.so.conf && ldconfig
 
-# docker build -f Dockerfile.environment -t jamesmcclain/gdal-build-environment:6 .
+# docker build -f Dockerfile.environment -t daunnc/gdal-build-environment:7 .

--- a/Docker/README.md
+++ b/Docker/README.md
@@ -1,6 +1,6 @@
 # Dockerfile.crossbuild #
 
-The file [`Dockerfile.crossbuild`](Dockerfile.crossbuild) is used to generate the Docker image `jamesmcclain/crossbuild` which contains the cross-compilers needed to generate Macintosh and Windows shared libraries.
+The file [`Dockerfile.crossbuild`](Dockerfile.crossbuild) is used to generate the Docker image `quay.io/geotrellis/gdal-warp-bindings-crossbuild` which contains the cross-compilers needed to generate Macintosh and Windows shared libraries.
 
 This image is based heavily on Manfred Touron's [`multiarch/crossbuild`](https://github.com/multiarch/crossbuild) image (in fact, it is just that image with non-x86 compilers removed, some unneeded packages removed, and based on Ubuntu 18.04 instead of Debian Jessie).
 
@@ -14,7 +14,7 @@ OSX/Darwin/Apple builds:
 
 # Dockerfile.environment #
 
-The file [`Dockerfile.environment`](Dockerfile.environment) is used to generate the Docker image `jamesmcclain/gdal-build-environment` which is derived from `jamesmcclain/crossbuild`.  The former adds Macintosh and Windows versions of OpenJDK (which provide necessary header files) as well as binary version of GDAL for Macintosh and Windows (which need to be linked-against).
+The file [`Dockerfile.environment`](Dockerfile.environment) is used to generate the Docker image `quay.io/geotrellis/gdal-warp-bindings-environment` which is derived from `quay.io/geotrellis/gdal-warp-bindings-crossbuild`.  The former adds Macintosh and Windows versions of OpenJDK (which provide necessary header files) as well as binary version of GDAL for Macintosh and Windows (which need to be linked-against).
 
 # License #
 

--- a/README.md
+++ b/README.md
@@ -11,9 +11,10 @@ APIs are provided for C and Java.
 
 These bindings require a GDAL installation on your machine with the appropriate matching version:
 
-| GDAL Warp Bindings | GDAL  | Shared Library {so|dylib|dll} |
-|--------------------|-------|-------------------------------|
-| 1.1.x              | 3.1.2 | libgdal.27                    |
+| GDAL Warp Bindings | OS | GDAL  | Shared Library {so,dylib,dll} |
+|--------------------|----|-------|-------------------------------|
+| 1.1.x | Linux, MacOS | 3.1.2 | libgdal.27 |
+| 1.1.x | Windows | 3.0.4 | -- |
 
 ## MacOS ##
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,28 @@ If one wishes to use [GDAL's VRT functionality](https://www.gdal.org/gdal_vrttut
 The code in this repository attempts to address that issue by wrapping GDAL datasets in objects which abstract one or more identical datasets; the wrapped datasets can be safely used from multiple threads with less contention than would be the case with a simple mutex around one GDAL dataset.
 APIs are provided for C and Java.
 
+# Installation #
+
+These bindings require a GDAL installation on your machine with the appropriate matching version:
+
+| GDAL Warp Bindings | GDAL  | Shared Library {so|dylib|dll} |
+|--------------------|-------|-------------------------------|
+| 1.1.x              | 3.1.2 | libgdal.27                    |
+
+## MacOS ##
+
+For MacOS users, you must also ensure that the appropriate shared libary file (dylib) above is symlinked to `/usr/local/lib` from your GDAL installation with matching version.
+
+For best results, we recommend explicitly installing the appropriate GDAL version via Conda and symlinking the appropriate lib. Here's an example for GDAL Warp Bindings 1.1.0 using GDAL 3.1.2:
+
+```shell
+conda create -n gdal-3.1.2
+conda activate gdal-3.1.2
+conda install -c conda-forge gdal==3.1.2
+sudo ln -s $(conda info --base)/envs/gdal-3.1.2/lib/libgdal.27.dylib /usr/local/lib/libgdal.27.dylib
+conda deactivate
+```
+
 # APIs #
 
 The C and Java APIs are very similar to each other.

--- a/scripts/publish-local.sh
+++ b/scripts/publish-local.sh
@@ -8,13 +8,13 @@ docker run -it --rm \
       -e CFLAGS="-Wall -Wno-sign-compare -Werror -O0 -ggdb3 -DSO_FINI -D_GNU_SOURCE" \
       -e BOOST_ROOT="/usr/local/include/boost_1_69_0" \
       -e JAVA_HOME="/usr/lib/jvm/java-8-openjdk-amd64" \
-      quay.io/geotrellis/gdal-warp-bindings-build:1 make -j4 -C src tests || exit -1
+      quay.io/quay.io/geotrellis/gdal-warp-bindings-environment:1 make -j4 -C src tests || exit -1
 
 docker run -it --rm \
       -v $(pwd):/workdir \
       -e CC=gcc -e CXX=g++ \
       -e JAVA_HOME="/usr/lib/jvm/java-8-openjdk-amd64" \
-      quay.io/geotrellis/gdal-warp-bindings-build:1 make -j4 -C src/experiments/thread pattern oversubscribe || exit -1
+      quay.io/quay.io/geotrellis/gdal-warp-bindings-environment:1 make -j4 -C src/experiments/thread pattern oversubscribe || exit -1
 
 rm -f $(find ./src | grep '\.o$')
 docker run -it --rm \
@@ -29,7 +29,7 @@ docker run -it --rm \
       -e CXXFLAGS="-I/usr/osxcross/SDK/MacOSX10.10.sdk/usr/include/c++/v1"  \
       -e BOOST_ROOT="/usr/local/include/boost_1_69_0" \
       -e LDFLAGS="-mmacosx-version-min=10.9 -L/macintosh/gdal/3.1.2/lib -lgdal -lstdc++ -lpthread -Wl,-rpath,/usr/local/lib" \
-      quay.io/geotrellis/gdal-warp-bindings-build:1 make -j4 -C src libgdalwarp_bindings.dylib || exit -1
+      quay.io/quay.io/geotrellis/gdal-warp-bindings-environment:1 make -j4 -C src libgdalwarp_bindings.dylib || exit -1
 
 docker run -it --rm \
       -v $(pwd):/workdir \
@@ -40,7 +40,7 @@ docker run -it --rm \
       -e GDALCFLAGS="-I/usr/local/include" \
       -e BOOST_ROOT="/usr/local/include/boost_1_69_0" \
       -e LDFLAGS="-L/windows/gdal/lib -lgdal_i -static-libgcc -static-libstdc++ -Wl,-Bstatic -lstdc++ -lpthread -Wl,-Bdynamic -lws2_32" \
-      quay.io/geotrellis/gdal-warp-bindings-build:1 make -j4 -C src gdalwarp_bindings.dll || exit -1
+      quay.io/quay.io/geotrellis/gdal-warp-bindings-environment:1 make -j4 -C src gdalwarp_bindings.dll || exit -1
 
 rm -f src/main/resources/*.so
 mv src/libgdalwarp_bindings.so src/main/resources/resources/

--- a/scripts/publish-local.sh
+++ b/scripts/publish-local.sh
@@ -8,13 +8,13 @@ docker run -it --rm \
       -e CFLAGS="-Wall -Wno-sign-compare -Werror -O0 -ggdb3 -DSO_FINI -D_GNU_SOURCE" \
       -e BOOST_ROOT="/usr/local/include/boost_1_69_0" \
       -e JAVA_HOME="/usr/lib/jvm/java-8-openjdk-amd64" \
-      jamesmcclain/gdal-build-environment:6 make -j4 -C src tests || exit -1
+      daunnc/gdal-build-environment:7 make -j4 -C src tests || exit -1
 
 docker run -it --rm \
       -v $(pwd):/workdir \
       -e CC=gcc -e CXX=g++ \
       -e JAVA_HOME="/usr/lib/jvm/java-8-openjdk-amd64" \
-      jamesmcclain/gdal-build-environment:6 make -j4 -C src/experiments/thread pattern oversubscribe || exit -1
+      daunnc/gdal-build-environment:7 make -j4 -C src/experiments/thread pattern oversubscribe || exit -1
 
 rm -f $(find ./src | grep '\.o$')
 docker run -it --rm \
@@ -29,7 +29,7 @@ docker run -it --rm \
       -e CXXFLAGS="-I/usr/osxcross/SDK/MacOSX10.10.sdk/usr/include/c++/v1"  \
       -e BOOST_ROOT="/usr/local/include/boost_1_69_0" \
       -e LDFLAGS="-mmacosx-version-min=10.9 -L/macintosh/gdal/3.1.2/lib -lgdal -lstdc++ -lpthread -Wl,-rpath,/usr/local/lib" \
-      jamesmcclain/gdal-build-environment:6 make -j4 -C src libgdalwarp_bindings.dylib || exit -1
+      daunnc/gdal-build-environment:7 make -j4 -C src libgdalwarp_bindings.dylib || exit -1
 
 docker run -it --rm \
       -v $(pwd):/workdir \
@@ -40,7 +40,7 @@ docker run -it --rm \
       -e GDALCFLAGS="-I/usr/local/include" \
       -e BOOST_ROOT="/usr/local/include/boost_1_69_0" \
       -e LDFLAGS="-L/windows/gdal/lib -lgdal_i -static-libgcc -static-libstdc++ -Wl,-Bstatic -lstdc++ -lpthread -Wl,-Bdynamic -lws2_32" \
-      jamesmcclain/gdal-build-environment:6 make -j4 -C src gdalwarp_bindings.dll || exit -1
+      daunnc/gdal-build-environment:7 make -j4 -C src gdalwarp_bindings.dll || exit -1
 
 rm -f src/main/resources/*.so
 mv src/libgdalwarp_bindings.so src/main/resources/resources/

--- a/scripts/publish-local.sh
+++ b/scripts/publish-local.sh
@@ -8,13 +8,13 @@ docker run -it --rm \
       -e CFLAGS="-Wall -Wno-sign-compare -Werror -O0 -ggdb3 -DSO_FINI -D_GNU_SOURCE" \
       -e BOOST_ROOT="/usr/local/include/boost_1_69_0" \
       -e JAVA_HOME="/usr/lib/jvm/java-8-openjdk-amd64" \
-      daunnc/gdal-build-environment:7 make -j4 -C src tests || exit -1
+      quay.io/geotrellis/gdal-warp-bindings-build:1 make -j4 -C src tests || exit -1
 
 docker run -it --rm \
       -v $(pwd):/workdir \
       -e CC=gcc -e CXX=g++ \
       -e JAVA_HOME="/usr/lib/jvm/java-8-openjdk-amd64" \
-      daunnc/gdal-build-environment:7 make -j4 -C src/experiments/thread pattern oversubscribe || exit -1
+      quay.io/geotrellis/gdal-warp-bindings-build:1 make -j4 -C src/experiments/thread pattern oversubscribe || exit -1
 
 rm -f $(find ./src | grep '\.o$')
 docker run -it --rm \
@@ -29,7 +29,7 @@ docker run -it --rm \
       -e CXXFLAGS="-I/usr/osxcross/SDK/MacOSX10.10.sdk/usr/include/c++/v1"  \
       -e BOOST_ROOT="/usr/local/include/boost_1_69_0" \
       -e LDFLAGS="-mmacosx-version-min=10.9 -L/macintosh/gdal/3.1.2/lib -lgdal -lstdc++ -lpthread -Wl,-rpath,/usr/local/lib" \
-      daunnc/gdal-build-environment:7 make -j4 -C src libgdalwarp_bindings.dylib || exit -1
+      quay.io/geotrellis/gdal-warp-bindings-build:1 make -j4 -C src libgdalwarp_bindings.dylib || exit -1
 
 docker run -it --rm \
       -v $(pwd):/workdir \
@@ -40,7 +40,7 @@ docker run -it --rm \
       -e GDALCFLAGS="-I/usr/local/include" \
       -e BOOST_ROOT="/usr/local/include/boost_1_69_0" \
       -e LDFLAGS="-L/windows/gdal/lib -lgdal_i -static-libgcc -static-libstdc++ -Wl,-Bstatic -lstdc++ -lpthread -Wl,-Bdynamic -lws2_32" \
-      daunnc/gdal-build-environment:7 make -j4 -C src gdalwarp_bindings.dll || exit -1
+      quay.io/geotrellis/gdal-warp-bindings-build:1 make -j4 -C src gdalwarp_bindings.dll || exit -1
 
 rm -f src/main/resources/*.so
 mv src/libgdalwarp_bindings.so src/main/resources/resources/

--- a/scripts/publish-local.sh
+++ b/scripts/publish-local.sh
@@ -28,7 +28,7 @@ docker run -it --rm \
       -e GDALCFLAGS="-I/macintosh/gdal/3.1.2/include" \
       -e CXXFLAGS="-I/usr/osxcross/SDK/MacOSX10.10.sdk/usr/include/c++/v1"  \
       -e BOOST_ROOT="/usr/local/include/boost_1_69_0" \
-      -e LDFLAGS="-mmacosx-version-min=10.9 -L/macintosh/gdal/3.1.2/lib -lgdal -lstdc++ -lpthread" \
+      -e LDFLAGS="-mmacosx-version-min=10.9 -L/macintosh/gdal/3.1.2/lib -lgdal -lstdc++ -lpthread -Wl,-rpath,/usr/local/lib" \
       jamesmcclain/gdal-build-environment:6 make -j4 -C src libgdalwarp_bindings.dylib || exit -1
 
 docker run -it --rm \

--- a/scripts/publish-local.sh
+++ b/scripts/publish-local.sh
@@ -8,13 +8,13 @@ docker run -it --rm \
       -e CFLAGS="-Wall -Wno-sign-compare -Werror -O0 -ggdb3 -DSO_FINI -D_GNU_SOURCE" \
       -e BOOST_ROOT="/usr/local/include/boost_1_69_0" \
       -e JAVA_HOME="/usr/lib/jvm/java-8-openjdk-amd64" \
-      daunnc/gdal-build-environment:6 make -j4 -C src tests || exit -1
+      jamesmcclain/gdal-build-environment:6 make -j4 -C src tests || exit -1
 
 docker run -it --rm \
       -v $(pwd):/workdir \
       -e CC=gcc -e CXX=g++ \
       -e JAVA_HOME="/usr/lib/jvm/java-8-openjdk-amd64" \
-      daunnc/gdal-build-environment:6 make -j4 -C src/experiments/thread pattern oversubscribe || exit -1
+      jamesmcclain/gdal-build-environment:6 make -j4 -C src/experiments/thread pattern oversubscribe || exit -1
 
 rm -f $(find ./src | grep '\.o$')
 docker run -it --rm \
@@ -29,7 +29,7 @@ docker run -it --rm \
       -e CXXFLAGS="-I/usr/osxcross/SDK/MacOSX10.10.sdk/usr/include/c++/v1"  \
       -e BOOST_ROOT="/usr/local/include/boost_1_69_0" \
       -e LDFLAGS="-mmacosx-version-min=10.9 -L/macintosh/gdal/3.1.2/lib -lgdal -lstdc++ -lpthread" \
-      daunnc/gdal-build-environment:6 make -j4 -C src libgdalwarp_bindings.dylib || exit -1
+      jamesmcclain/gdal-build-environment:6 make -j4 -C src libgdalwarp_bindings.dylib || exit -1
 
 docker run -it --rm \
       -v $(pwd):/workdir \
@@ -40,7 +40,7 @@ docker run -it --rm \
       -e GDALCFLAGS="-I/usr/local/include" \
       -e BOOST_ROOT="/usr/local/include/boost_1_69_0" \
       -e LDFLAGS="-L/windows/gdal/lib -lgdal_i -static-libgcc -static-libstdc++ -Wl,-Bstatic -lstdc++ -lpthread -Wl,-Bdynamic -lws2_32" \
-      daunnc/gdal-build-environment:6 make -j4 -C src gdalwarp_bindings.dll || exit -1
+      jamesmcclain/gdal-build-environment:6 make -j4 -C src gdalwarp_bindings.dll || exit -1
 
 rm -f src/main/resources/*.so
 mv src/libgdalwarp_bindings.so src/main/resources/resources/

--- a/scripts/publish-local.sh
+++ b/scripts/publish-local.sh
@@ -8,13 +8,13 @@ docker run -it --rm \
       -e CFLAGS="-Wall -Wno-sign-compare -Werror -O0 -ggdb3 -DSO_FINI -D_GNU_SOURCE" \
       -e BOOST_ROOT="/usr/local/include/boost_1_69_0" \
       -e JAVA_HOME="/usr/lib/jvm/java-8-openjdk-amd64" \
-      quay.io/quay.io/geotrellis/gdal-warp-bindings-environment:1 make -j4 -C src tests || exit -1
+      quay.io/geotrellis/gdal-warp-bindings-environment:1 make -j4 -C src tests || exit -1
 
 docker run -it --rm \
       -v $(pwd):/workdir \
       -e CC=gcc -e CXX=g++ \
       -e JAVA_HOME="/usr/lib/jvm/java-8-openjdk-amd64" \
-      quay.io/quay.io/geotrellis/gdal-warp-bindings-environment:1 make -j4 -C src/experiments/thread pattern oversubscribe || exit -1
+      quay.io/geotrellis/gdal-warp-bindings-environment:1 make -j4 -C src/experiments/thread pattern oversubscribe || exit -1
 
 rm -f $(find ./src | grep '\.o$')
 docker run -it --rm \
@@ -29,7 +29,7 @@ docker run -it --rm \
       -e CXXFLAGS="-I/usr/osxcross/SDK/MacOSX10.10.sdk/usr/include/c++/v1"  \
       -e BOOST_ROOT="/usr/local/include/boost_1_69_0" \
       -e LDFLAGS="-mmacosx-version-min=10.9 -L/macintosh/gdal/3.1.2/lib -lgdal -lstdc++ -lpthread -Wl,-rpath,/usr/local/lib" \
-      quay.io/quay.io/geotrellis/gdal-warp-bindings-environment:1 make -j4 -C src libgdalwarp_bindings.dylib || exit -1
+      quay.io/geotrellis/gdal-warp-bindings-environment:1 make -j4 -C src libgdalwarp_bindings.dylib || exit -1
 
 docker run -it --rm \
       -v $(pwd):/workdir \
@@ -40,7 +40,7 @@ docker run -it --rm \
       -e GDALCFLAGS="-I/usr/local/include" \
       -e BOOST_ROOT="/usr/local/include/boost_1_69_0" \
       -e LDFLAGS="-L/windows/gdal/lib -lgdal_i -static-libgcc -static-libstdc++ -Wl,-Bstatic -lstdc++ -lpthread -Wl,-Bdynamic -lws2_32" \
-      quay.io/quay.io/geotrellis/gdal-warp-bindings-environment:1 make -j4 -C src gdalwarp_bindings.dll || exit -1
+      quay.io/geotrellis/gdal-warp-bindings-environment:1 make -j4 -C src gdalwarp_bindings.dll || exit -1
 
 rm -f src/main/resources/*.so
 mv src/libgdalwarp_bindings.so src/main/resources/resources/

--- a/scripts/tests.sh
+++ b/scripts/tests.sh
@@ -28,7 +28,7 @@ docker run -it --rm \
       -e GDALCFLAGS="-I/macintosh/gdal/3.1.2/include" \
       -e CXXFLAGS="-I/usr/osxcross/SDK/MacOSX10.10.sdk/usr/include/c++/v1"  \
       -e BOOST_ROOT="/usr/local/include/boost_1_69_0" \
-      -e LDFLAGS="-mmacosx-version-min=10.9 -L/macintosh/gdal/3.1.2/lib -lgdal -lstdc++ -lpthread" \
+      -e LDFLAGS="-mmacosx-version-min=10.9 -L/macintosh/gdal/3.1.2/lib -lgdal -lstdc++ -lpthread -Wl,-rpath,/usr/local/lib" \
       jamesmcclain/gdal-build-environment:6 make -j4 -C src libgdalwarp_bindings.dylib || exit -1
 
 docker run -it --rm \

--- a/scripts/tests.sh
+++ b/scripts/tests.sh
@@ -8,13 +8,13 @@ docker run -it --rm \
       -e CFLAGS="-Wall -Wno-sign-compare -Werror -O0 -ggdb3 -DSO_FINI -D_GNU_SOURCE" \
       -e BOOST_ROOT="/usr/local/include/boost_1_69_0" \
       -e JAVA_HOME="/usr/lib/jvm/java-8-openjdk-amd64" \
-      quay.io/quay.io/geotrellis/gdal-warp-bindings-environment:1 make -j4 -C src tests || exit -1
+      quay.io/geotrellis/gdal-warp-bindings-environment:1 make -j4 -C src tests || exit -1
 
 docker run -it --rm \
       -v $(pwd):/workdir \
       -e CC=gcc -e CXX=g++ \
       -e JAVA_HOME="/usr/lib/jvm/java-8-openjdk-amd64" \
-      quay.io/quay.io/geotrellis/gdal-warp-bindings-environment:1 make -j4 -C src/experiments/thread pattern oversubscribe || exit -1
+      quay.io/geotrellis/gdal-warp-bindings-environment:1 make -j4 -C src/experiments/thread pattern oversubscribe || exit -1
 
 rm -f $(find | grep '\.o$')
 docker run -it --rm \
@@ -29,7 +29,7 @@ docker run -it --rm \
       -e CXXFLAGS="-I/usr/osxcross/SDK/MacOSX10.10.sdk/usr/include/c++/v1"  \
       -e BOOST_ROOT="/usr/local/include/boost_1_69_0" \
       -e LDFLAGS="-mmacosx-version-min=10.9 -L/macintosh/gdal/3.1.2/lib -lgdal -lstdc++ -lpthread -Wl,-rpath,/usr/local/lib" \
-      quay.io/quay.io/geotrellis/gdal-warp-bindings-environment:1 make -j4 -C src libgdalwarp_bindings.dylib || exit -1
+      quay.io/geotrellis/gdal-warp-bindings-environment:1 make -j4 -C src libgdalwarp_bindings.dylib || exit -1
 
 docker run -it --rm \
       -v $(pwd):/workdir \
@@ -40,7 +40,7 @@ docker run -it --rm \
       -e GDALCFLAGS="-I/usr/local/include" \
       -e BOOST_ROOT="/usr/local/include/boost_1_69_0" \
       -e LDFLAGS="-L/windows/gdal/lib -lgdal_i -static-libgcc -static-libstdc++ -Wl,-Bstatic -lstdc++ -lpthread -Wl,-Bdynamic -lws2_32" \
-      quay.io/quay.io/geotrellis/gdal-warp-bindings-environment:1 make -j4 -C src gdalwarp_bindings.dll || exit -1
+      quay.io/geotrellis/gdal-warp-bindings-environment:1 make -j4 -C src gdalwarp_bindings.dll || exit -1
 
 rm -f src/main/resources/*.so
 mv src/libgdalwarp_bindings.so src/main/resources/resources/

--- a/scripts/tests.sh
+++ b/scripts/tests.sh
@@ -8,13 +8,13 @@ docker run -it --rm \
       -e CFLAGS="-Wall -Wno-sign-compare -Werror -O0 -ggdb3 -DSO_FINI -D_GNU_SOURCE" \
       -e BOOST_ROOT="/usr/local/include/boost_1_69_0" \
       -e JAVA_HOME="/usr/lib/jvm/java-8-openjdk-amd64" \
-      quay.io/geotrellis/gdal-warp-bindings-build:1 make -j4 -C src tests || exit -1
+      quay.io/quay.io/geotrellis/gdal-warp-bindings-environment:1 make -j4 -C src tests || exit -1
 
 docker run -it --rm \
       -v $(pwd):/workdir \
       -e CC=gcc -e CXX=g++ \
       -e JAVA_HOME="/usr/lib/jvm/java-8-openjdk-amd64" \
-      quay.io/geotrellis/gdal-warp-bindings-build:1 make -j4 -C src/experiments/thread pattern oversubscribe || exit -1
+      quay.io/quay.io/geotrellis/gdal-warp-bindings-environment:1 make -j4 -C src/experiments/thread pattern oversubscribe || exit -1
 
 rm -f $(find | grep '\.o$')
 docker run -it --rm \
@@ -29,7 +29,7 @@ docker run -it --rm \
       -e CXXFLAGS="-I/usr/osxcross/SDK/MacOSX10.10.sdk/usr/include/c++/v1"  \
       -e BOOST_ROOT="/usr/local/include/boost_1_69_0" \
       -e LDFLAGS="-mmacosx-version-min=10.9 -L/macintosh/gdal/3.1.2/lib -lgdal -lstdc++ -lpthread -Wl,-rpath,/usr/local/lib" \
-      quay.io/geotrellis/gdal-warp-bindings-build:1 make -j4 -C src libgdalwarp_bindings.dylib || exit -1
+      quay.io/quay.io/geotrellis/gdal-warp-bindings-environment:1 make -j4 -C src libgdalwarp_bindings.dylib || exit -1
 
 docker run -it --rm \
       -v $(pwd):/workdir \
@@ -40,7 +40,7 @@ docker run -it --rm \
       -e GDALCFLAGS="-I/usr/local/include" \
       -e BOOST_ROOT="/usr/local/include/boost_1_69_0" \
       -e LDFLAGS="-L/windows/gdal/lib -lgdal_i -static-libgcc -static-libstdc++ -Wl,-Bstatic -lstdc++ -lpthread -Wl,-Bdynamic -lws2_32" \
-      quay.io/geotrellis/gdal-warp-bindings-build:1 make -j4 -C src gdalwarp_bindings.dll || exit -1
+      quay.io/quay.io/geotrellis/gdal-warp-bindings-environment:1 make -j4 -C src gdalwarp_bindings.dll || exit -1
 
 rm -f src/main/resources/*.so
 mv src/libgdalwarp_bindings.so src/main/resources/resources/

--- a/scripts/tests.sh
+++ b/scripts/tests.sh
@@ -8,13 +8,13 @@ docker run -it --rm \
       -e CFLAGS="-Wall -Wno-sign-compare -Werror -O0 -ggdb3 -DSO_FINI -D_GNU_SOURCE" \
       -e BOOST_ROOT="/usr/local/include/boost_1_69_0" \
       -e JAVA_HOME="/usr/lib/jvm/java-8-openjdk-amd64" \
-      daunnc/gdal-build-environment:6 make -j4 -C src tests || exit -1
+      jamesmcclain/gdal-build-environment:6 make -j4 -C src tests || exit -1
 
 docker run -it --rm \
       -v $(pwd):/workdir \
       -e CC=gcc -e CXX=g++ \
       -e JAVA_HOME="/usr/lib/jvm/java-8-openjdk-amd64" \
-      daunnc/gdal-build-environment:6 make -j4 -C src/experiments/thread pattern oversubscribe || exit -1
+      jamesmcclain/gdal-build-environment:6 make -j4 -C src/experiments/thread pattern oversubscribe || exit -1
 
 rm -f $(find | grep '\.o$')
 docker run -it --rm \
@@ -29,7 +29,7 @@ docker run -it --rm \
       -e CXXFLAGS="-I/usr/osxcross/SDK/MacOSX10.10.sdk/usr/include/c++/v1"  \
       -e BOOST_ROOT="/usr/local/include/boost_1_69_0" \
       -e LDFLAGS="-mmacosx-version-min=10.9 -L/macintosh/gdal/3.1.2/lib -lgdal -lstdc++ -lpthread" \
-      daunnc/gdal-build-environment:6 make -j4 -C src libgdalwarp_bindings.dylib || exit -1
+      jamesmcclain/gdal-build-environment:6 make -j4 -C src libgdalwarp_bindings.dylib || exit -1
 
 docker run -it --rm \
       -v $(pwd):/workdir \
@@ -40,7 +40,7 @@ docker run -it --rm \
       -e GDALCFLAGS="-I/usr/local/include" \
       -e BOOST_ROOT="/usr/local/include/boost_1_69_0" \
       -e LDFLAGS="-L/windows/gdal/lib -lgdal_i -static-libgcc -static-libstdc++ -Wl,-Bstatic -lstdc++ -lpthread -Wl,-Bdynamic -lws2_32" \
-      daunnc/gdal-build-environment:6 make -j4 -C src gdalwarp_bindings.dll || exit -1
+      jamesmcclain/gdal-build-environment:6 make -j4 -C src gdalwarp_bindings.dll || exit -1
 
 rm -f src/main/resources/*.so
 mv src/libgdalwarp_bindings.so src/main/resources/resources/

--- a/scripts/tests.sh
+++ b/scripts/tests.sh
@@ -8,13 +8,13 @@ docker run -it --rm \
       -e CFLAGS="-Wall -Wno-sign-compare -Werror -O0 -ggdb3 -DSO_FINI -D_GNU_SOURCE" \
       -e BOOST_ROOT="/usr/local/include/boost_1_69_0" \
       -e JAVA_HOME="/usr/lib/jvm/java-8-openjdk-amd64" \
-      jamesmcclain/gdal-build-environment:6 make -j4 -C src tests || exit -1
+      daunnc/gdal-build-environment:7 make -j4 -C src tests || exit -1
 
 docker run -it --rm \
       -v $(pwd):/workdir \
       -e CC=gcc -e CXX=g++ \
       -e JAVA_HOME="/usr/lib/jvm/java-8-openjdk-amd64" \
-      jamesmcclain/gdal-build-environment:6 make -j4 -C src/experiments/thread pattern oversubscribe || exit -1
+      daunnc/gdal-build-environment:7 make -j4 -C src/experiments/thread pattern oversubscribe || exit -1
 
 rm -f $(find | grep '\.o$')
 docker run -it --rm \
@@ -29,7 +29,7 @@ docker run -it --rm \
       -e CXXFLAGS="-I/usr/osxcross/SDK/MacOSX10.10.sdk/usr/include/c++/v1"  \
       -e BOOST_ROOT="/usr/local/include/boost_1_69_0" \
       -e LDFLAGS="-mmacosx-version-min=10.9 -L/macintosh/gdal/3.1.2/lib -lgdal -lstdc++ -lpthread -Wl,-rpath,/usr/local/lib" \
-      jamesmcclain/gdal-build-environment:6 make -j4 -C src libgdalwarp_bindings.dylib || exit -1
+      daunnc/gdal-build-environment:7 make -j4 -C src libgdalwarp_bindings.dylib || exit -1
 
 docker run -it --rm \
       -v $(pwd):/workdir \
@@ -40,7 +40,7 @@ docker run -it --rm \
       -e GDALCFLAGS="-I/usr/local/include" \
       -e BOOST_ROOT="/usr/local/include/boost_1_69_0" \
       -e LDFLAGS="-L/windows/gdal/lib -lgdal_i -static-libgcc -static-libstdc++ -Wl,-Bstatic -lstdc++ -lpthread -Wl,-Bdynamic -lws2_32" \
-      jamesmcclain/gdal-build-environment:6 make -j4 -C src gdalwarp_bindings.dll || exit -1
+      daunnc/gdal-build-environment:7 make -j4 -C src gdalwarp_bindings.dll || exit -1
 
 rm -f src/main/resources/*.so
 mv src/libgdalwarp_bindings.so src/main/resources/resources/

--- a/scripts/tests.sh
+++ b/scripts/tests.sh
@@ -8,13 +8,13 @@ docker run -it --rm \
       -e CFLAGS="-Wall -Wno-sign-compare -Werror -O0 -ggdb3 -DSO_FINI -D_GNU_SOURCE" \
       -e BOOST_ROOT="/usr/local/include/boost_1_69_0" \
       -e JAVA_HOME="/usr/lib/jvm/java-8-openjdk-amd64" \
-      daunnc/gdal-build-environment:7 make -j4 -C src tests || exit -1
+      quay.io/geotrellis/gdal-warp-bindings-build:1 make -j4 -C src tests || exit -1
 
 docker run -it --rm \
       -v $(pwd):/workdir \
       -e CC=gcc -e CXX=g++ \
       -e JAVA_HOME="/usr/lib/jvm/java-8-openjdk-amd64" \
-      daunnc/gdal-build-environment:7 make -j4 -C src/experiments/thread pattern oversubscribe || exit -1
+      quay.io/geotrellis/gdal-warp-bindings-build:1 make -j4 -C src/experiments/thread pattern oversubscribe || exit -1
 
 rm -f $(find | grep '\.o$')
 docker run -it --rm \
@@ -29,7 +29,7 @@ docker run -it --rm \
       -e CXXFLAGS="-I/usr/osxcross/SDK/MacOSX10.10.sdk/usr/include/c++/v1"  \
       -e BOOST_ROOT="/usr/local/include/boost_1_69_0" \
       -e LDFLAGS="-mmacosx-version-min=10.9 -L/macintosh/gdal/3.1.2/lib -lgdal -lstdc++ -lpthread -Wl,-rpath,/usr/local/lib" \
-      daunnc/gdal-build-environment:7 make -j4 -C src libgdalwarp_bindings.dylib || exit -1
+      quay.io/geotrellis/gdal-warp-bindings-build:1 make -j4 -C src libgdalwarp_bindings.dylib || exit -1
 
 docker run -it --rm \
       -v $(pwd):/workdir \
@@ -40,7 +40,7 @@ docker run -it --rm \
       -e GDALCFLAGS="-I/usr/local/include" \
       -e BOOST_ROOT="/usr/local/include/boost_1_69_0" \
       -e LDFLAGS="-L/windows/gdal/lib -lgdal_i -static-libgcc -static-libstdc++ -Wl,-Bstatic -lstdc++ -lpthread -Wl,-Bdynamic -lws2_32" \
-      daunnc/gdal-build-environment:7 make -j4 -C src gdalwarp_bindings.dll || exit -1
+      quay.io/geotrellis/gdal-warp-bindings-build:1 make -j4 -C src gdalwarp_bindings.dll || exit -1
 
 rm -f src/main/resources/*.so
 mv src/libgdalwarp_bindings.so src/main/resources/resources/


### PR DESCRIPTION
# Overview

We were compiling macos gdal-warp-bindings with homebrew gdal leading to the errors in #98 and #73. This PR fixes those issues with a two-pronged approach:
1. Compile bindings with the conda gdal binary package: This updates the linker path for `libgdal.dylib` to `@rpath/libgdal.dylib`, removing the `HOMEBREW_PREFIX`.
2. Add ld flag `-rpath=/usr/local/lib` so that a common dir is in the rpath of our libgdalwarp_bindings.dylib and the linker can find the gdal dylib at a common location

This is still a bit of a mess. We currently build gdal 3.1.2 but `brew install gdal` is currently 3.2.0, which switches to `libgdal.28.dylib`(3.2)  from `libgdal.27.dylib` (3.1.2). So, in the simplest case, if you install gdal with brew, and don't already have 3.1.2 installed, you'll still get a linker error. _HOWEVER..._ now you can install gdal into a conda env and symlink the appropriate dylib to /usr/local/lib and these bindings will work:

```
conda create -n gdal-3.1.2
conda activate gdal-3.1.2
conda install -c conda-forge gdal==3.1.2
sudo ln -s <path/to/conda/install>/envs/gdal-3.1.2/lib/libgdal.27.dylib /usr/local/lib/libgdal.27.dylib
conda deactivate
cd path/to/my/project
./sbt run
[info] welcome to sbt 1.4.0 (AdoptOpenJDK Java 1.8.0_252)
[info] loading project definition from /Users/azavea/src/gdal-rs-test/project
[info] loading settings for project gdal-rs-test from build.sbt ...
[info] set current project to gdal-bug (in build file:/Users/azavea/src/gdal-rs-test/)
[info] running Main 
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
Extent(0.0, 0.0, 806.0, 568.0)
[success] Total time: 3 s, completed Nov 12, 2020 4:08:59 PM
```

Unfortunately this doesn't address #91, although at this point I'm not sure we need to since we can symlink the appropriate gdal dylib installed anywhere to /usr/local/lib and it will work.

## Demo

Here's a zipped sbt project you can download and run to verify that this build fixes the issue. Ensure you have a `libgdal.27.dylib` in `/usr/local/lib`, either because you have a brew install of gdal 3.1.2 there, or you installed it via conda and manually linked it there, as described above:

[gdal-warp-bindings-macos-test.zip](https://github.com/geotrellis/gdal-warp-bindings/files/5537383/gdal-warp-bindings-macos-test.zip)


Closes #98 
Closes #73 

cc @metasim