### PR TITLE
Initial ARM64 (aarch64-linux-gnu) Support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,14 +1,14 @@
 version: 2.1
 
 executors:
-  gdal-build-executor:
+  gdal-build-executor-amd64:
     docker:
-      - image: quay.io/geotrellis/gdal-warp-bindings-environment:1
+      - image: quay.io/geotrellis/gdal-warp-bindings-environment:amd64-2
     working_directory: /workdir
 
 jobs:
   build-linux:
-    executor: gdal-build-executor
+    executor: gdal-build-executor-amd64
     environment:
       CC: gcc
       CXX: g++
@@ -20,7 +20,7 @@ jobs:
           at: /tmp/workdir/
       - checkout
       - run:
-          name: Build Linux binaries and run unit tests
+          name: Build AMD64 Linux binaries and run unit tests
           command: |
             ln -s /tmp/c41078a1.tif src/experiments/data/c41078a1.tif
             make -j4 -C src tests
@@ -31,7 +31,7 @@ jobs:
             - libgdalwarp_bindings.so
 
   build-macos:
-    executor: gdal-build-executor
+    executor: gdal-build-executor-amd64
     environment:
       OSXCROSS_NO_INCLUDE_PATH_WARNINGS: 1
       CROSS_TRIPLE: x86_64-apple-darwin14
@@ -62,7 +62,7 @@ jobs:
             - libgdalwarp_bindings.dylib
 
   build-windows:
-    executor: gdal-build-executor
+    executor: gdal-build-executor-amd64
     environment:
       CROSS_TRIPLE: x86_64-w64-mingw32
       OS: win32
@@ -88,7 +88,7 @@ jobs:
             - gdalwarp_bindings.dll
 
   publish:
-    executor: gdal-build-executor
+    executor: gdal-build-executor-amd64
     steps:
       - attach_workspace:
           at: /tmp/workdir/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,13 +6,18 @@ executors:
       - image: quay.io/geotrellis/gdal-warp-bindings-environment:amd64-2
     working_directory: /workdir
 
+  gdal-build-executor-arm64:
+    docker:
+      - image: quay.io/geotrellis/gdal-warp-bindings-environment:arm64-2
+    working_directory: /workdir
+
 jobs:
-  build-linux:
+  build-linux-amd64:
     executor: gdal-build-executor-amd64
     environment:
       CC: gcc
       CXX: g++
-      CFLAGS: "-Wall -Wno-sign-compare -Werror -O0 -ggdb3 -DSO_FINI -D_GNU_SOURCE"
+      CFLAGS: "-Wall -Werror -Og -ggdb3 -DSO_FINI -D_GNU_SOURCE"
       BOOST_ROOT: "/usr/local/include/boost_1_69_0"
       JAVA_HOME: "/usr/lib/jvm/java-8-openjdk-amd64"
     steps:
@@ -28,9 +33,34 @@ jobs:
       - persist_to_workspace:
           root: src
           paths:
-            - libgdalwarp_bindings.so
+            - com_azavea_gdal_GDALWarp.h
+            - libgdalwarp_bindings-amd64.so
 
-  build-macos:
+  build-linux-arm64:
+    executor: gdal-build-executor-arm64
+    environment:
+      ARCH: arm64
+      CC: aarch64-linux-gnu-gcc-8
+      CXX: aarch64-linux-gnu-g++-8
+      CFLAGS: "-Wall -Og -ggdb3 -DSO_FINI -D_GNU_SOURCE"
+      BOOST_ROOT: "/usr/local/include/boost_1_69_0"
+      JAVA_HOME: "/usr/lib/jvm/java-8-openjdk-arm64"
+    steps:
+      - attach_workspace:
+          at: /tmp/workdir/
+      - checkout
+      - run:
+          name: Build ARM64 Linux binaries
+          command: |
+            touch /workdir/src/main/java/com/azavea/gdal/GDALWarp.class
+            cp -f /tmp/workdir/*.h /workdir/src/
+            make -j4 -C src libgdalwarp_bindings-arm64.so
+      - persist_to_workspace:
+          root: src
+          paths:
+            - libgdalwarp_bindings-arm64.so
+
+  build-macos-amd64:
     executor: gdal-build-executor-amd64
     environment:
       OSXCROSS_NO_INCLUDE_PATH_WARNINGS: 1
@@ -39,7 +69,7 @@ jobs:
       SO: dylib
       CC: cc
       CXX: c++
-      CFLAGS: "-Wall -Werror -O0 -ggdb3"
+      CFLAGS: "-Wall -Werror -Og -ggdb3"
       JAVA_HOME: "/macintosh/jdk8u202-b08/Contents/Home"
       GDALCFLAGS: "-I/macintosh/gdal/3.1.2/include"
       CXXFLAGS: "-I/usr/osxcross/SDK/MacOSX10.10.sdk/usr/include/c++/v1"
@@ -54,19 +84,22 @@ jobs:
           at: /tmp/workdir/
       - checkout
       - run:
-          name: Build MacOS binaries
-          command: make -j4 -C src libgdalwarp_bindings.dylib
+          name: Build MacOS AMD64 binaries
+          command: |
+            touch /workdir/src/main/java/com/azavea/gdal/GDALWarp.class
+            cp -f /tmp/workdir/*.h /workdir/src/
+            make -j4 -C src libgdalwarp_bindings-amd64.dylib
       - persist_to_workspace:
           root: src
           paths:
-            - libgdalwarp_bindings.dylib
+            - libgdalwarp_bindings-amd64.dylib
 
-  build-windows:
+  build-windows-amd64:
     executor: gdal-build-executor-amd64
     environment:
       CROSS_TRIPLE: x86_64-w64-mingw32
       OS: win32
-      CFLAGS: "-Wall -Werror -Os -g"
+      CFLAGS: "-Wall -Werror -Og -g"
       JAVA_HOME: "/windows/jdk8u202-b08"
       GDALCFLAGS: "-I/usr/local/include"
       BOOST_ROOT: "/usr/local/include/boost_1_69_0"
@@ -80,12 +113,15 @@ jobs:
           at: /tmp/workdir/
       - checkout
       - run:
-          name: Build Windows binaries
-          command: make -j4 -C src gdalwarp_bindings.dll
+          name: Build Windows AMD64 binaries
+          command: |
+            touch /workdir/src/main/java/com/azavea/gdal/GDALWarp.class
+            cp -f /tmp/workdir/*.h /workdir/src/
+            make -j4 -C src gdalwarp_bindings-amd64.dll
       - persist_to_workspace:
           root: src
           paths:
-            - gdalwarp_bindings.dll
+            - gdalwarp_bindings-amd64.dll
 
   publish:
     executor: gdal-build-executor-amd64
@@ -98,7 +134,7 @@ jobs:
           command: |
             apt-get install maven -y &&
             rm -f src/main/resources/resources/.gitkeep &&
-            cp -f /tmp/workdir/* src/main/resources/resources/ &&
+            cp -f /tmp/workdir/*.so /tmp/workdir/*.dylib /tmp/workdir/*.dll src/main/resources/resources/ &&
             mvn package &&
             if [ ! -z "${GPG_KEY}" ]; then
               mkdir -p ~/.m2 &&
@@ -112,19 +148,31 @@ jobs:
 workflows:
   build-publish:
     jobs:
-      - build-linux:
+      - build-linux-amd64:
           filters:
             branches:
               only: /.*/
             tags:
               only: /^v.*/
-      - build-macos:
+      - build-linux-arm64:
+          requires:
+            - build-linux-amd64
           filters:
             branches:
               only: /.*/
             tags:
               only: /^v.*/
-      - build-windows:
+      - build-macos-amd64:
+          requires:
+            - build-linux-amd64
+          filters:
+            branches:
+              only: /.*/
+            tags:
+              only: /^v.*/
+      - build-windows-amd64:
+          requires:
+            - build-linux-amd64
           filters:
             branches:
               only: /.*/
@@ -132,9 +180,10 @@ workflows:
               only: /^v.*/
       - publish:
           requires:
-            - build-linux
-            - build-macos
-            - build-windows
+            - build-linux-amd64
+            - build-linux-arm64
+            - build-macos-amd64
+            - build-windows-amd64
           filters:
             branches:
               only: /.*/

--- a/Docker/Dockerfile.crossbuild
+++ b/Docker/Dockerfile.crossbuild
@@ -101,4 +101,4 @@ WORKDIR /workdir
 RUN wget -k 'https://raw.githubusercontent.com/multiarch/crossbuild/master/assets/crossbuild' -O /usr/bin/crossbuild && \
     chmod ugo+x /usr/bin/crossbuild
 
-# docker build -f Dockerfile.crossbuild -t quay.io/geotrellis/gdal-warp-bindings-crossbuild:2 .
+# docker build -f Dockerfile.crossbuild -t quay.io/geotrellis/gdal-warp-bindings-crossbuild:amd64-2 .

--- a/Docker/Dockerfile.crossbuild
+++ b/Docker/Dockerfile.crossbuild
@@ -1,29 +1,29 @@
-FROM buildpack-deps:bionic-curl
-MAINTAINER Manfred Touron <m@42.am> (https://github.com/moul)
+FROM buildpack-deps:focal-curl
+LABEL maintainer="Manfred Touron <m@42.am> (https://github.com/moul)"
 
 # Install deps
 RUN set -x; \
-    apt-get update                                     \
- && apt-get install -y -q                              \
-        autoconf                                       \
-        automake                                       \
-        autotools-dev                                  \
-        bc                                             \
-        build-essential                                \
-        clang                                          \
-        curl                                           \
-        devscripts                                     \
-        gdb                                            \
-        git-core                                       \
-        libtool                                        \
-        llvm                                           \
-        multistrap                                     \
-        patch                                          \
-        software-properties-common                     \
-        wget                                           \
-        xz-utils                                       \
-        cmake                                          \
-        mingw-w64                                      \
+    apt-get update                 \
+ && apt-get install -y -q          \
+        autoconf                   \
+        automake                   \
+        autotools-dev              \
+        bc                         \
+        build-essential            \
+        clang                      \
+        curl                       \
+        devscripts                 \
+        gdb                        \
+        git-core                   \
+        libtool                    \
+        llvm                       \
+        multistrap                 \
+        patch                      \
+        software-properties-common \
+        wget                       \
+        xz-utils                   \
+        cmake                      \
+        mingw-w64                  \
  && apt-get clean
 
 # Install OSx cross-tools
@@ -44,20 +44,22 @@ ENV OSXCROSS_REPO="${osxcross_repo}"                   \
     DARWIN_OSX_VERSION_MIN="${darwin_osx_version_min}" \
     DARWIN_SDK_URL="${darwin_sdk_url}"
 
-RUN mkdir -p "/tmp/osxcross"                                                                                   \
- && cd "/tmp/osxcross"                                                                                         \
- && curl -sLo osxcross.tar.gz "https://codeload.github.com/${OSXCROSS_REPO}/tar.gz/${OSXCROSS_REVISION}"  \
- && tar --strip=1 -xzf osxcross.tar.gz                                                                         \
- && rm -f osxcross.tar.gz                                                                                      \
- && curl -sLo tarballs/MacOSX${DARWIN_SDK_VERSION}.sdk.tar.xz                                                  \
-             "${DARWIN_SDK_URL}"                \
- && yes "" | SDK_VERSION="${DARWIN_SDK_VERSION}" OSX_VERSION_MIN="${DARWIN_OSX_VERSION_MIN}" ./build.sh                               \
- && mv target /usr/osxcross                                                                                    \
- && mv tools /usr/osxcross/                                                                                    \
- && ln -sf ../tools/osxcross-macports /usr/osxcross/bin/omp                                                    \
- && ln -sf ../tools/osxcross-macports /usr/osxcross/bin/osxcross-macports                                      \
- && ln -sf ../tools/osxcross-macports /usr/osxcross/bin/osxcross-mp                                            \
- && rm -rf /tmp/osxcross                                                                                       \
+COPY build.patch /tmp/build.patch
+
+RUN mkdir -p "/tmp/osxcross"                                                                             \
+ && cd "/tmp/osxcross"                                                                                   \
+ && curl -sLo osxcross.tar.gz "https://codeload.github.com/${OSXCROSS_REPO}/tar.gz/${OSXCROSS_REVISION}" \
+ && tar --strip=1 -xzf osxcross.tar.gz                                                                   \
+ && rm -f osxcross.tar.gz                                                                                \
+ && curl -sLo tarballs/MacOSX${DARWIN_SDK_VERSION}.sdk.tar.xz "${DARWIN_SDK_URL}"                        \
+ && patch -p0 < /tmp/build.patch                                                                         \
+ && yes "" | SDK_VERSION="${DARWIN_SDK_VERSION}" OSX_VERSION_MIN="${DARWIN_OSX_VERSION_MIN}" ./build.sh  \
+ && mv target /usr/osxcross                                                                              \
+ && mv tools /usr/osxcross/                                                                              \
+ && ln -sf ../tools/osxcross-macports /usr/osxcross/bin/omp                                              \
+ && ln -sf ../tools/osxcross-macports /usr/osxcross/bin/osxcross-macports                                \
+ && ln -sf ../tools/osxcross-macports /usr/osxcross/bin/osxcross-mp                                      \
+ && rm -rf /tmp/osxcross                                                                                 \
  && rm -rf "/usr/osxcross/SDK/MacOSX${DARWIN_SDK_VERSION}.sdk/usr/share/man"
 
 
@@ -99,4 +101,4 @@ WORKDIR /workdir
 RUN wget -k 'https://raw.githubusercontent.com/multiarch/crossbuild/master/assets/crossbuild' -O /usr/bin/crossbuild && \
     chmod ugo+x /usr/bin/crossbuild
 
-# docker build -f Dockerfile.crossbuild -t quay.io/geotrellis/gdal-warp-bindings-crossbuild:latest .
+# docker build -f Dockerfile.crossbuild -t quay.io/geotrellis/gdal-warp-bindings-crossbuild:2 .

--- a/Docker/Dockerfile.environment
+++ b/Docker/Dockerfile.environment
@@ -1,4 +1,4 @@
-FROM quay.io/geotrellis/gdal-warp-bindings-crossbuild:1
+FROM quay.io/geotrellis/gdal-warp-bindings-crossbuild:2
 LABEL maintainer="Azavea <info@azavea.com>"
 
 RUN apt-get update -y && \
@@ -27,7 +27,7 @@ RUN cd /usr/local/src && \
 RUN wget 'https://download.osgeo.org/geotiff/samples/usgs/c41078a1.tif' -k -O /tmp/c41078a1.tif
 
 # Boost
-RUN wget 'https://dl.bintray.com/boostorg/release/1.69.0/source/boost_1_69_0.tar.bz2' -O /tmp/boost.tar.bz2 && \
+RUN wget 'https://boostorg.jfrog.io/artifactory/main/release/1.69.0/source/boost_1_69_0.tar.bz2' -O /tmp/boost.tar.bz2 && \
   mkdir -p /usr/local/include && \
   cd /usr/local/include && \
   tar axvf /tmp/boost.tar.bz2 && \
@@ -59,4 +59,4 @@ RUN mkdir -p /windows && \
 # Linkage
 RUN echo '/usr/local/lib' >> /etc/ld.so.conf && ldconfig
 
-# docker build -f Dockerfile.environment -t quay.io/geotrellis/gdal-warp-bindings-environment:latest .
+# docker build -f Dockerfile.environment -t quay.io/geotrellis/gdal-warp-bindings-environment:2 .

--- a/Docker/Dockerfile.environment
+++ b/Docker/Dockerfile.environment
@@ -1,4 +1,4 @@
-FROM quay.io/geotrellis/gdal-warp-bindings-crossbuild:2
+FROM quay.io/geotrellis/gdal-warp-bindings-crossbuild:amd64-2
 LABEL maintainer="Azavea <info@azavea.com>"
 
 RUN apt-get update -y && \
@@ -59,4 +59,4 @@ RUN mkdir -p /windows && \
 # Linkage
 RUN echo '/usr/local/lib' >> /etc/ld.so.conf && ldconfig
 
-# docker build -f Dockerfile.environment -t quay.io/geotrellis/gdal-warp-bindings-environment:2 .
+# docker build -f Dockerfile.environment -t quay.io/geotrellis/gdal-warp-bindings-environment:amd64-2 .

--- a/Docker/Dockerfile.environment-amd64
+++ b/Docker/Dockerfile.environment-amd64
@@ -59,4 +59,4 @@ RUN mkdir -p /windows && \
 # Linkage
 RUN echo '/usr/local/lib' >> /etc/ld.so.conf && ldconfig
 
-# docker build -f Dockerfile.environment -t quay.io/geotrellis/gdal-warp-bindings-environment:amd64-2 .
+# docker build -f Dockerfile.environment-amd64 -t quay.io/geotrellis/gdal-warp-bindings-environment:amd64-2 .

--- a/Docker/Dockerfile.environment-arm64
+++ b/Docker/Dockerfile.environment-arm64
@@ -1,0 +1,37 @@
+FROM buildpack-deps:buster-curl
+LABEL maintainer="Azavea <info@azavea.com>"
+
+# Install tools and libraries
+RUN dpkg --add-architecture arm64                                                            \
+ && apt-get update -y                                                                        \
+ && apt-get install -y -q          \
+        autoconf                   \
+        automake                   \
+        autotools-dev              \
+        bc                         \
+        binfmt-support             \
+        libtool                    \
+        patch                      \
+        wget                       \
+        xz-utils                   \
+        cmake                      \
+	software-properties-common \
+ && apt-get clean
+
+RUN apt-add-repository 'deb http://security.debian.org/debian-security stretch/updates main'
+
+RUN apt update -y              \
+ && apt-get install -y -q      \
+    crossbuild-essential-arm64 \
+    openjdk-8-jdk:arm64        \
+    libgdal-dev:arm64          \
+ && apt-get clean
+
+# Boost
+RUN wget 'https://boostorg.jfrog.io/artifactory/main/release/1.69.0/source/boost_1_69_0.tar.bz2' -O /tmp/boost.tar.bz2 && \
+  mkdir -p /usr/local/include && \
+  cd /usr/local/include && \
+  tar axvf /tmp/boost.tar.bz2 && \
+  rm /tmp/boost.tar.bz2
+
+# docker build -f Dockerfile.environment-arm64 -t quay.io/geotrellis/gdal-warp-bindings-environment:arm64-2 .

--- a/Docker/LICENSE
+++ b/Docker/LICENSE
@@ -1,6 +1,6 @@
 The MIT License
 
-Copyright (c) 2019 Azavea
+Copyright (c) 2019-2021 Azavea
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Docker/README.md
+++ b/Docker/README.md
@@ -14,7 +14,9 @@ OSX/Darwin/Apple builds:
 
 # Dockerfile.environment #
 
-The file [`Dockerfile.environment`](Dockerfile.environment) is used to generate the Docker image `quay.io/geotrellis/gdal-warp-bindings-environment` which is derived from `quay.io/geotrellis/gdal-warp-bindings-crossbuild`.  The former adds Macintosh and Windows versions of OpenJDK (which provide necessary header files) as well as binary version of GDAL for Macintosh and Windows (which need to be linked-against).
+The file [`Dockerfile.environment-amd64`](Dockerfile.environment-amd64) is used to generate the Docker images found under `quay.io/geotrellis/gdal-warp-bindings-environment` that contain `amd64` compilers.  The Docker images with `amd64` images are derived from `quay.io/geotrellis/gdal-warp-bindings-crossbuild`.  The Dockerfile mentioned above adds Macintosh, Windows, and `amd64` Linux versions of OpenJDK and GDAL.
+
+The file [`Dockerfile.environment-arm64`](Dockerfile.environment-arm64) is used to generate the Docker images found under `quay.io/geotrellis/gdal-warp-bindings-environment` that contain `arm64` compilers.  The `arm64` image is not derived directly from a Debian Buster base image and contains a `aarch64-gnu-linux` toolchain as well as OpenJDK and GDAL.
 
 # License #
 

--- a/Docker/README.md
+++ b/Docker/README.md
@@ -2,7 +2,7 @@
 
 The file [`Dockerfile.crossbuild`](Dockerfile.crossbuild) is used to generate the Docker image `quay.io/geotrellis/gdal-warp-bindings-crossbuild` which contains the cross-compilers needed to generate Macintosh and Windows shared libraries.
 
-This image is based heavily on Manfred Touron's [`multiarch/crossbuild`](https://github.com/multiarch/crossbuild) image (in fact, it is just that image with non-x86 compilers removed, some unneeded packages removed, and based on Ubuntu 18.04 instead of Debian Jessie).
+This image is based heavily on Manfred Touron's [`multiarch/crossbuild`](https://github.com/multiarch/crossbuild) image (in fact, it is just that image with non-x86 compilers removed, some unneeded packages removed, and based on Ubuntu 20.04 instead of Debian Jessie).
 
 An important legal note from that project's [README.md](https://github.com/multiarch/crossbuild/blob/3d8c2ea811534cc6f4d82f54892f5494681e2591/README.md) concerning Apple's OSX SDK is reproduced below:
 

--- a/Docker/build.patch
+++ b/Docker/build.patch
@@ -1,0 +1,10 @@
+--- build.sh.old	2021-05-15 16:49:49.371757665 -0400
++++ build.sh	2021-05-15 16:50:17.519863520 -0400
+@@ -154,6 +154,7 @@
+ CONFFLAGS+="--disable-clang-as "
+ [ -n "$DISABLE_LTO_SUPPORT" ] && CONFFLAGS+="--disable-lto-support "
+ ./configure $CONFFLAGS
++cp /usr/include/llvm-c-10/llvm-c/ExternC.h /tmp/osxcross/build/cctools-877.5-ld64-253.3_4f8ad51/cctools/include/llvm-c/
+ $MAKE -j$JOBS
+ $MAKE install -j$JOBS
+ popd &>/dev/null

--- a/scripts/publish-local.sh
+++ b/scripts/publish-local.sh
@@ -2,21 +2,34 @@
 
 ln -s /tmp/c41078a1.tif src/experiments/data/c41078a1.tif # sic
 
+# Linux AMD64
 docker run -it --rm \
       -v $(pwd):/workdir \
       -e CC=gcc -e CXX=g++ \
-      -e CFLAGS="-Wall -Wno-sign-compare -Werror -O0 -ggdb3 -DSO_FINI -D_GNU_SOURCE" \
+      -e CFLAGS="-Wall -Werror -Og -ggdb3 -DSO_FINI -D_GNU_SOURCE" \
       -e BOOST_ROOT="/usr/local/include/boost_1_69_0" \
       -e JAVA_HOME="/usr/lib/jvm/java-8-openjdk-amd64" \
       quay.io/geotrellis/gdal-warp-bindings-environment:amd64-2 make -j4 -C src tests || exit -1
-
 docker run -it --rm \
       -v $(pwd):/workdir \
       -e CC=gcc -e CXX=g++ \
       -e JAVA_HOME="/usr/lib/jvm/java-8-openjdk-amd64" \
       quay.io/geotrellis/gdal-warp-bindings-environment:amd64-2 make -j4 -C src/experiments/thread pattern oversubscribe || exit -1
+rm -f $(find | grep '\.o$')
 
-rm -f $(find ./src | grep '\.o$')
+# Linux ARM64
+docker run -it --rm \
+      -v $(pwd):/workdir \
+      -e ARCH=arm64 \
+      -e CC=aarch64-linux-gnu-gcc-8 -e CXX=aarch64-linux-gnu-g++-8 \
+      -e CFLAGS="-Wall -Werror -Og -ggdb3 -DSO_FINI -D_GNU_SOURCE" \
+      -e BOOST_ROOT="/usr/local/include/boost_1_69_0" \
+      -e JAVA_HOME="/usr/lib/jvm/java-8-openjdk-arm64" \
+      -w /workdir \
+      quay.io/geotrellis/gdal-warp-bindings-environment:arm64-2 make -j4 -C src libgdalwarp_bindings-arm64.so || exit -1
+rm -f $(find | grep '\.o$')
+
+# MacOS AMD64
 docker run -it --rm \
       -v $(pwd):/workdir \
       -e OSXCROSS_NO_INCLUDE_PATH_WARNINGS=1 \
@@ -29,8 +42,10 @@ docker run -it --rm \
       -e CXXFLAGS="-I/usr/osxcross/SDK/MacOSX10.10.sdk/usr/include/c++/v1"  \
       -e BOOST_ROOT="/usr/local/include/boost_1_69_0" \
       -e LDFLAGS="-mmacosx-version-min=10.9 -L/macintosh/gdal/3.1.2/lib -lgdal -lstdc++ -lpthread -Wl,-rpath,/usr/local/lib" \
-      quay.io/geotrellis/gdal-warp-bindings-environment:amd64-2 make -j4 -C src libgdalwarp_bindings.dylib || exit -1
+      quay.io/geotrellis/gdal-warp-bindings-environment:amd64-2 make -j4 -C src libgdalwarp_bindings-amd64.dylib || exit -1
+rm -f $(find | grep '\.o$')
 
+# Windows AMD64
 docker run -it --rm \
       -v $(pwd):/workdir \
       -e CROSS_TRIPLE=x86_64-w64-mingw32 \
@@ -40,12 +55,13 @@ docker run -it --rm \
       -e GDALCFLAGS="-I/usr/local/include" \
       -e BOOST_ROOT="/usr/local/include/boost_1_69_0" \
       -e LDFLAGS="-L/windows/gdal/lib -lgdal_i -static-libgcc -static-libstdc++ -Wl,-Bstatic -lstdc++ -lpthread -Wl,-Bdynamic -lws2_32" \
-      quay.io/geotrellis/gdal-warp-bindings-environment:amd64-2 make -j4 -C src gdalwarp_bindings.dll || exit -1
+      quay.io/geotrellis/gdal-warp-bindings-environment:amd64-2 make -j4 -C src gdalwarp_bindings-amd64.dll || exit -1
+rm -f $(find | grep '\.obj$')
 
 rm -f src/main/resources/*.so
-mv src/libgdalwarp_bindings.so src/main/resources/resources/
-mv src/libgdalwarp_bindings.dylib src/main/resources/resources/
-mv src/gdalwarp_bindings.dll src/main/resources/resources/
+mv src/libgdalwarp_bindings*.so src/main/resources/resources/
+mv src/libgdalwarp_bindings*.dylib src/main/resources/resources/
+mv src/gdalwarp_bindings*.dll src/main/resources/resources/
 mvn install
 
 rm -f $(find src | grep '\.\(o\|obj\|dylib\|dll\|so\|class\)$')

--- a/scripts/publish-local.sh
+++ b/scripts/publish-local.sh
@@ -8,13 +8,13 @@ docker run -it --rm \
       -e CFLAGS="-Wall -Wno-sign-compare -Werror -O0 -ggdb3 -DSO_FINI -D_GNU_SOURCE" \
       -e BOOST_ROOT="/usr/local/include/boost_1_69_0" \
       -e JAVA_HOME="/usr/lib/jvm/java-8-openjdk-amd64" \
-      quay.io/geotrellis/gdal-warp-bindings-environment:1 make -j4 -C src tests || exit -1
+      quay.io/geotrellis/gdal-warp-bindings-environment:amd64-2 make -j4 -C src tests || exit -1
 
 docker run -it --rm \
       -v $(pwd):/workdir \
       -e CC=gcc -e CXX=g++ \
       -e JAVA_HOME="/usr/lib/jvm/java-8-openjdk-amd64" \
-      quay.io/geotrellis/gdal-warp-bindings-environment:1 make -j4 -C src/experiments/thread pattern oversubscribe || exit -1
+      quay.io/geotrellis/gdal-warp-bindings-environment:amd64-2 make -j4 -C src/experiments/thread pattern oversubscribe || exit -1
 
 rm -f $(find ./src | grep '\.o$')
 docker run -it --rm \
@@ -29,7 +29,7 @@ docker run -it --rm \
       -e CXXFLAGS="-I/usr/osxcross/SDK/MacOSX10.10.sdk/usr/include/c++/v1"  \
       -e BOOST_ROOT="/usr/local/include/boost_1_69_0" \
       -e LDFLAGS="-mmacosx-version-min=10.9 -L/macintosh/gdal/3.1.2/lib -lgdal -lstdc++ -lpthread -Wl,-rpath,/usr/local/lib" \
-      quay.io/geotrellis/gdal-warp-bindings-environment:1 make -j4 -C src libgdalwarp_bindings.dylib || exit -1
+      quay.io/geotrellis/gdal-warp-bindings-environment:amd64-2 make -j4 -C src libgdalwarp_bindings.dylib || exit -1
 
 docker run -it --rm \
       -v $(pwd):/workdir \
@@ -40,7 +40,7 @@ docker run -it --rm \
       -e GDALCFLAGS="-I/usr/local/include" \
       -e BOOST_ROOT="/usr/local/include/boost_1_69_0" \
       -e LDFLAGS="-L/windows/gdal/lib -lgdal_i -static-libgcc -static-libstdc++ -Wl,-Bstatic -lstdc++ -lpthread -Wl,-Bdynamic -lws2_32" \
-      quay.io/geotrellis/gdal-warp-bindings-environment:1 make -j4 -C src gdalwarp_bindings.dll || exit -1
+      quay.io/geotrellis/gdal-warp-bindings-environment:amd64-2 make -j4 -C src gdalwarp_bindings.dll || exit -1
 
 rm -f src/main/resources/*.so
 mv src/libgdalwarp_bindings.so src/main/resources/resources/

--- a/scripts/tests.sh
+++ b/scripts/tests.sh
@@ -8,13 +8,13 @@ docker run -it --rm \
       -e CFLAGS="-Wall -Wno-sign-compare -Werror -O0 -ggdb3 -DSO_FINI -D_GNU_SOURCE" \
       -e BOOST_ROOT="/usr/local/include/boost_1_69_0" \
       -e JAVA_HOME="/usr/lib/jvm/java-8-openjdk-amd64" \
-      quay.io/geotrellis/gdal-warp-bindings-environment:1 make -j4 -C src tests || exit -1
+      quay.io/geotrellis/gdal-warp-bindings-environment:amd64-2 make -j4 -C src tests || exit -1
 
 docker run -it --rm \
       -v $(pwd):/workdir \
       -e CC=gcc -e CXX=g++ \
       -e JAVA_HOME="/usr/lib/jvm/java-8-openjdk-amd64" \
-      quay.io/geotrellis/gdal-warp-bindings-environment:1 make -j4 -C src/experiments/thread pattern oversubscribe || exit -1
+      quay.io/geotrellis/gdal-warp-bindings-environment:amd64-2 make -j4 -C src/experiments/thread pattern oversubscribe || exit -1
 
 rm -f $(find | grep '\.o$')
 docker run -it --rm \
@@ -29,7 +29,7 @@ docker run -it --rm \
       -e CXXFLAGS="-I/usr/osxcross/SDK/MacOSX10.10.sdk/usr/include/c++/v1"  \
       -e BOOST_ROOT="/usr/local/include/boost_1_69_0" \
       -e LDFLAGS="-mmacosx-version-min=10.9 -L/macintosh/gdal/3.1.2/lib -lgdal -lstdc++ -lpthread -Wl,-rpath,/usr/local/lib" \
-      quay.io/geotrellis/gdal-warp-bindings-environment:1 make -j4 -C src libgdalwarp_bindings.dylib || exit -1
+      quay.io/geotrellis/gdal-warp-bindings-environment:amd64-2 make -j4 -C src libgdalwarp_bindings.dylib || exit -1
 
 docker run -it --rm \
       -v $(pwd):/workdir \
@@ -40,7 +40,7 @@ docker run -it --rm \
       -e GDALCFLAGS="-I/usr/local/include" \
       -e BOOST_ROOT="/usr/local/include/boost_1_69_0" \
       -e LDFLAGS="-L/windows/gdal/lib -lgdal_i -static-libgcc -static-libstdc++ -Wl,-Bstatic -lstdc++ -lpthread -Wl,-Bdynamic -lws2_32" \
-      quay.io/geotrellis/gdal-warp-bindings-environment:1 make -j4 -C src gdalwarp_bindings.dll || exit -1
+      quay.io/geotrellis/gdal-warp-bindings-environment:amd64-2 make -j4 -C src gdalwarp_bindings.dll || exit -1
 
 rm -f src/main/resources/*.so
 mv src/libgdalwarp_bindings.so src/main/resources/resources/

--- a/scripts/tests.sh
+++ b/scripts/tests.sh
@@ -2,21 +2,34 @@
 
 ln -s /tmp/c41078a1.tif src/experiments/data/c41078a1.tif # sic
 
+# Linux AMD64
 docker run -it --rm \
       -v $(pwd):/workdir \
       -e CC=gcc -e CXX=g++ \
-      -e CFLAGS="-Wall -Wno-sign-compare -Werror -O0 -ggdb3 -DSO_FINI -D_GNU_SOURCE" \
+      -e CFLAGS="-Wall -Werror -Og -ggdb3 -DSO_FINI -D_GNU_SOURCE" \
       -e BOOST_ROOT="/usr/local/include/boost_1_69_0" \
       -e JAVA_HOME="/usr/lib/jvm/java-8-openjdk-amd64" \
       quay.io/geotrellis/gdal-warp-bindings-environment:amd64-2 make -j4 -C src tests || exit -1
-
 docker run -it --rm \
       -v $(pwd):/workdir \
       -e CC=gcc -e CXX=g++ \
       -e JAVA_HOME="/usr/lib/jvm/java-8-openjdk-amd64" \
       quay.io/geotrellis/gdal-warp-bindings-environment:amd64-2 make -j4 -C src/experiments/thread pattern oversubscribe || exit -1
-
 rm -f $(find | grep '\.o$')
+
+# Linux ARM64
+docker run -it --rm \
+      -v $(pwd):/workdir \
+      -e ARCH=arm64 \
+      -e CC=aarch64-linux-gnu-gcc-8 -e CXX=aarch64-linux-gnu-g++-8 \
+      -e CFLAGS="-Wall -Werror -Og -ggdb3 -DSO_FINI -D_GNU_SOURCE" \
+      -e BOOST_ROOT="/usr/local/include/boost_1_69_0" \
+      -e JAVA_HOME="/usr/lib/jvm/java-8-openjdk-arm64" \
+      -w /workdir \
+      quay.io/geotrellis/gdal-warp-bindings-environment:arm64-2 make -j4 -C src libgdalwarp_bindings-arm64.so || exit -1
+rm -f $(find | grep '\.o$')
+
+# MacOS AMD64
 docker run -it --rm \
       -v $(pwd):/workdir \
       -e OSXCROSS_NO_INCLUDE_PATH_WARNINGS=1 \
@@ -29,8 +42,10 @@ docker run -it --rm \
       -e CXXFLAGS="-I/usr/osxcross/SDK/MacOSX10.10.sdk/usr/include/c++/v1"  \
       -e BOOST_ROOT="/usr/local/include/boost_1_69_0" \
       -e LDFLAGS="-mmacosx-version-min=10.9 -L/macintosh/gdal/3.1.2/lib -lgdal -lstdc++ -lpthread -Wl,-rpath,/usr/local/lib" \
-      quay.io/geotrellis/gdal-warp-bindings-environment:amd64-2 make -j4 -C src libgdalwarp_bindings.dylib || exit -1
+      quay.io/geotrellis/gdal-warp-bindings-environment:amd64-2 make -j4 -C src libgdalwarp_bindings-amd64.dylib || exit -1
+rm -f $(find | grep '\.o$')
 
+# Windows AMD64
 docker run -it --rm \
       -v $(pwd):/workdir \
       -e CROSS_TRIPLE=x86_64-w64-mingw32 \
@@ -40,13 +55,14 @@ docker run -it --rm \
       -e GDALCFLAGS="-I/usr/local/include" \
       -e BOOST_ROOT="/usr/local/include/boost_1_69_0" \
       -e LDFLAGS="-L/windows/gdal/lib -lgdal_i -static-libgcc -static-libstdc++ -Wl,-Bstatic -lstdc++ -lpthread -Wl,-Bdynamic -lws2_32" \
-      quay.io/geotrellis/gdal-warp-bindings-environment:amd64-2 make -j4 -C src gdalwarp_bindings.dll || exit -1
+      quay.io/geotrellis/gdal-warp-bindings-environment:amd64-2 make -j4 -C src gdalwarp_bindings-amd64.dll || exit -1
+rm -f $(find | grep '\.obj$')
 
 rm -f src/main/resources/*.so
-mv src/libgdalwarp_bindings.so src/main/resources/resources/
-mv src/libgdalwarp_bindings.dylib src/main/resources/resources/
-mv src/gdalwarp_bindings.dll src/main/resources/resources/
-mvn package
+mv src/libgdalwarp_bindings*.so src/main/resources/resources/
+mv src/libgdalwarp_bindings*.dylib src/main/resources/resources/
+mv src/gdalwarp_bindings*.dll src/main/resources/resources/
 
+rm -f $(find src | grep '\.\(o\|obj\|dylib\|dll\|so\|class\)$')
 rm -f src/com_azavea_gdal_GDALWarp.h
 rm -f src/experiments/thread/oversubscribe src/experiments/thread/pattern

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,4 +1,4 @@
-CFLAGS ?= -Wall -Werror -O0 -ggdb3 -D_GNU_SOURCE
+CFLAGS ?= -Wall -Werror -Og -ggdb3 -D_GNU_SOURCE
 CXXFLAGS ?= -std=c++14
 LDFLAGS ?= $(shell pkg-config gdal --libs) -l:libstdc++.a -lpthread
 JAVA_HOME ?= /usr/lib/jvm/java-11-openjdk-amd64

--- a/src/Makefile
+++ b/src/Makefile
@@ -6,9 +6,11 @@ GDALCFLAGS ?= $(shell pkg-config gdal --cflags)
 BOOST_ROOT ?= /usr/include
 OS ?= linux
 SO ?= so
+ARCH ?= amd64
 HEADERS = bindings.h types.hpp flat_lru_cache.hpp locked_dataset.hpp tokens.hpp errorcodes.hpp
 
-all: tests libgdalwarp_bindings.$(SO)
+
+all: tests libgdalwarp_bindings-$(ARCH).$(SO)
 
 com_azavea_gdal_GDALWarp.o: com_azavea_gdal_GDALWarp.c
 	$(MAKE) -C main java/com/azavea/gdal/GDALWarp.class
@@ -24,16 +26,16 @@ com_azavea_gdal_GDALWarp.obj: com_azavea_gdal_GDALWarp.c
 %.obj: %.cpp $(HEADERS)
 	$(CXX) $(GDALCFLAGS) $(CFLAGS) $(CXXFLAGS) -I$(BOOST_ROOT) -fPIC $< -c -o $@
 
-libgdalwarp_bindings.$(SO): com_azavea_gdal_GDALWarp.o bindings.o tokens.o errorcodes.o
+libgdalwarp_bindings-$(ARCH).$(SO): com_azavea_gdal_GDALWarp.o bindings.o tokens.o errorcodes.o
 	$(CC) $(CFLAGS) $^ $(LDFLAGS) -shared -o $@
 
-gdalwarp_bindings.dll: com_azavea_gdal_GDALWarp.obj bindings.obj tokens.obj errorcodes.obj
+gdalwarp_bindings-$(ARCH).dll: com_azavea_gdal_GDALWarp.obj bindings.obj tokens.obj errorcodes.obj
 	$(CC) $(CFLAGS) $^ $(LDFLAGS) -shared -o $@
 
 experiments/data:
 	$(MAKE) -C experiments data/c41078a1.tif
 
-tests: libgdalwarp_bindings.$(SO)
+tests: libgdalwarp_bindings-$(ARCH).$(SO)
 	$(MAKE) -C unit_tests tests
 	$(MAKE) -C main tests
 
@@ -44,7 +46,7 @@ clean:
 	$(MAKE) -C main clean
 
 cleaner: clean
-	rm -f libgdalwarp_bindings.$(SO) com_azavea_gdal_GDALWarp.h
+	rm -f libgdalwarp_bindings-$(ARCH).$(SO) com_azavea_gdal_GDALWarp.h
 	$(MAKE) -C experiments cleaner
 	$(MAKE) -C unit_tests cleaner
 	$(MAKE) -C main cleaner

--- a/src/bindings.cpp
+++ b/src/bindings.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Azavea
+ * Copyright 2019-2021 Azavea
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/bindings.h
+++ b/src/bindings.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Azavea
+ * Copyright 2019-2021 Azavea
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/com_azavea_gdal_GDALWarp.c
+++ b/src/com_azavea_gdal_GDALWarp.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Azavea
+ * Copyright 2019-2021 Azavea
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/errorcodes.cpp
+++ b/src/errorcodes.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Azavea
+ * Copyright 2019-2021 Azavea
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/errorcodes.hpp
+++ b/src/errorcodes.hpp
@@ -21,7 +21,7 @@
 #include <gdal.h>
 
 // warpbindings error codes should not intersect GDAL error codes
-// see https://gdal.org/doxygen/cpl__error_8h.html 
+// see https://gdal.org/doxygen/cpl__error_8h.html
 #define ATTEMPTS_EXCEEDED 100
 
 void errno_init();

--- a/src/experiments/thread/Makefile
+++ b/src/experiments/thread/Makefile
@@ -1,38 +1,39 @@
 CFLAGS ?= -Wall -Werror -Og -ggdb3
 CXXFLAGS ?= -std=c++1z
 GDALCFLAGS ?= $(shell pkg-config gdal --cflags)
-LDFLAGS ?= $(shell pkg-config gdal --libs) -L$(shell pwd) -lgdalwarp_bindings -lstdc++ -lpthread
+LDFLAGS ?= $(shell pkg-config gdal --libs) -L$(shell pwd) -lgdalwarp_bindings-$(ARCH) -lstdc++ -lpthread
 BOOST_ROOT ?= /usr/include
 SO ?= so
+ARCH ?= amd64
 
 all: rawthread wrapthread pattern oversubscribe metadata
 
-../../libgdalwarp_bindings.$(SO):
-	$(MAKE) -C ../.. libgdalwarp_bindings.$(SO)
+../../libgdalwarp_bindings-$(ARCH).$(SO):
+	$(MAKE) -C ../.. libgdalwarp_bindings-$(ARCH).$(SO)
 
-libgdalwarp_bindings.$(SO): ../../libgdalwarp_bindings.$(SO)
+libgdalwarp_bindings-$(ARCH).$(SO): ../../libgdalwarp_bindings-$(ARCH).$(SO)
 	ln -s $< $@
 
-rawthread: rawthread.o libgdalwarp_bindings.$(SO)
+rawthread: rawthread.o libgdalwarp_bindings-$(ARCH).$(SO)
 	$(CC) $< $(LDFLAGS) -lboost_timer -o $@
 
-wrapthread: wrapthread.o libgdalwarp_bindings.$(SO)
+wrapthread: wrapthread.o libgdalwarp_bindings-$(ARCH).$(SO)
 	$(CC) $< $(LDFLAGS) -lboost_timer -o $@
 
-pattern: pattern.o libgdalwarp_bindings.$(SO)
+pattern: pattern.o libgdalwarp_bindings-$(ARCH).$(SO)
 	$(CC) $< $(LDFLAGS) -o $@
 
-oversubscribe: oversubscribe.o libgdalwarp_bindings.$(SO)
+oversubscribe: oversubscribe.o libgdalwarp_bindings-$(ARCH).$(SO)
 	$(CC) $< $(LDFLAGS) -o $@
 
-metadata: metadata.o libgdalwarp_bindings.$(SO)
+metadata: metadata.o libgdalwarp_bindings-$(ARCH).$(SO)
 	$(CC) $< $(LDFLAGS) -lboost_timer -o $@
 
 %.o: %.cpp
 	$(CXX) $(CFLAGS) $(CXXFLAGS) $(GDALCFLAGS) -I$(BOOST_ROOT) $< -c -o $@
 
 clean:
-	rm -f *.o  libgdalwarp_bindings.$(SO)
+	rm -f *.o  libgdalwarp_bindings-$(ARCH).$(SO)
 
 cleaner: clean
 	rm -f rawthread wrapthread pattern oversubscribe metadata

--- a/src/experiments/thread/metadata.cpp
+++ b/src/experiments/thread/metadata.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Azavea
+ * Copyright 2019-2021 Azavea
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/experiments/thread/oversubscribe.cpp
+++ b/src/experiments/thread/oversubscribe.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Azavea
+ * Copyright 2019-2021 Azavea
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/experiments/thread/pattern.cpp
+++ b/src/experiments/thread/pattern.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Azavea
+ * Copyright 2019-2021 Azavea
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/experiments/thread/rawthread.cpp
+++ b/src/experiments/thread/rawthread.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Azavea
+ * Copyright 2019-2021 Azavea
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/experiments/thread/wrapthread.cpp
+++ b/src/experiments/thread/wrapthread.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Azavea
+ * Copyright 2019-2021 Azavea
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/flat_lru_cache.hpp
+++ b/src/flat_lru_cache.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Azavea
+ * Copyright 2019-2021 Azavea
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/locked_dataset.hpp
+++ b/src/locked_dataset.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Azavea
+ * Copyright 2019-2021 Azavea
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -639,7 +639,7 @@ public:
         if (pthread_mutex_trylock(&m_dataset_lock) != 0)
         {
             return false;
-        }        
+        }
         // If the lock could be obtained but the reference count is
         // not zero, return false
         else if (m_use_count != 0)

--- a/src/main/GDALWarpMetadataTest.java
+++ b/src/main/GDALWarpMetadataTest.java
@@ -1,6 +1,5 @@
-
 /*
- * Copyright 2019 Azavea
+ * Copyright 2019-2021 Azavea
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/GDALWarpThreadTest.java
+++ b/src/main/GDALWarpThreadTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Azavea
+ * Copyright 2019-2021 Azavea
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/Makefile
+++ b/src/main/Makefile
@@ -1,16 +1,18 @@
 JAVA ?= java
 JAVAC ?= javac
 SO ?= so
+ARCH ?= amd64
+
 
 .PHONY: tests clean cleaner cleanest
 
-gdalwarp.jar: resources/libgdalwarp_bindings.$(SO) java/com/azavea/gdal/GDALWarp.class java/cz/adamh/utils/NativeUtils.class
+gdalwarp.jar: resources/libgdalwarp_bindings-$(ARCH).$(SO) java/com/azavea/gdal/GDALWarp.class java/cz/adamh/utils/NativeUtils.class
 	(cd java ; jar -cvf ../$@ com/azavea/gdal/*.class cz/adamh/utils/*.class ../resources/*)
 
-../libgdalwarp_bindings.$(SO):
-	$(MAKE) -C .. libgdalwarp_bindings.$(SO)
+../libgdalwarp_bindings-$(ARCH).$(SO):
+	$(MAKE) -C .. libgdalwarp_bindings-$(ARCH).$(SO)
 
-resources/libgdalwarp_bindings.$(SO): ../libgdalwarp_bindings.$(SO)
+resources/libgdalwarp_bindings-$(ARCH).$(SO): ../libgdalwarp_bindings-$(ARCH).$(SO)
 	cp -f $< $@
 
 java/com/azavea/gdal/GDALWarp.class java/cz/adamh/utils/NativeUtils.class: java/com/azavea/gdal/GDALWarp.java java/cz/adamh/utils/NativeUtils.java
@@ -38,6 +40,6 @@ clean:
 
 cleaner: clean
 	rm -f gdalwarp.jar
-	rm -f resources/libgdalwarp_bindings.$(SO)
+	rm -f resources/libgdalwarp_bindings-$(ARCH).$(SO)
 
 cleanest: cleaner

--- a/src/main/java/com/azavea/gdal/GDALWarp.java
+++ b/src/main/java/com/azavea/gdal/GDALWarp.java
@@ -21,9 +21,10 @@ import java.io.UnsupportedEncodingException;
 import cz.adamh.utils.NativeUtils;
 
 public class GDALWarp {
-        private static final String GDALWARP_BINDINGS_RESOURCE_ELF = "/resources/libgdalwarp_bindings.so";
-        private static final String GDALWARP_BINDINGS_RESOURCE_MACHO = "/resources/libgdalwarp_bindings.dylib";
-        private static final String GDALWARP_BINDINGS_RESOURCE_DLL = "/resources/gdalwarp_bindings.dll";
+        private static final String GDALWARP_BINDINGS_RESOURCE_ARM64_ELF = "/resources/libgdalwarp_bindings-arm64.so";
+        private static final String GDALWARP_BINDINGS_RESOURCE_AMD64_ELF = "/resources/libgdalwarp_bindings-amd64.so";
+        private static final String GDALWARP_BINDINGS_RESOURCE_AMD64_MACHO = "/resources/libgdalwarp_bindings-amd64.dylib";
+        private static final String GDALWARP_BINDINGS_RESOURCE_AMD64_DLL = "/resources/gdalwarp_bindings-amd64.dll";
 
         public static final int GDT_Unknown = 0;
         public static final int GDT_Byte = 1;
@@ -118,18 +119,28 @@ public class GDALWarp {
         public static void init(int size) throws Exception {
 
                 String os = System.getProperty("os.name").toLowerCase();
+                String arch = System.getProperty("os.arch").toLowerCase();
 
                 // Try to load ELF shared object from JAR file ...
                 if (os.contains("linux")) {
-                        NativeUtils.loadLibraryFromJar(GDALWARP_BINDINGS_RESOURCE_ELF);
+                        // AMD64
+                        if (arch.contains("amd64"))
+                        {
+                                NativeUtils.loadLibraryFromJar(GDALWARP_BINDINGS_RESOURCE_AMD64_ELF);
+                        }
+                        // ARM64
+                        else if (arch.contains("arm64"))
+                        {
+                                NativeUtils.loadLibraryFromJar(GDALWARP_BINDINGS_RESOURCE_ARM64_ELF);
+                        }
                 }
                 // Try to Load Mach-O shared object from JAR file ...
                 else if (os.contains("mac")) {
-                        NativeUtils.loadLibraryFromJar(GDALWARP_BINDINGS_RESOURCE_MACHO);
+                        NativeUtils.loadLibraryFromJar(GDALWARP_BINDINGS_RESOURCE_AMD64_MACHO);
                 }
                 // Try to load Windows DLL from JAR file ...
                 else if (os.contains("win")) {
-                        NativeUtils.loadLibraryFromJar(GDALWARP_BINDINGS_RESOURCE_DLL);
+                        NativeUtils.loadLibraryFromJar(GDALWARP_BINDINGS_RESOURCE_AMD64_DLL);
                 } else {
                         throw new Exception("Unsupported platform");
                 }

--- a/src/main/java/com/azavea/gdal/GDALWarp.java
+++ b/src/main/java/com/azavea/gdal/GDALWarp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Azavea
+ * Copyright 2019-2021 Azavea
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/azavea/gdal/GDALWarp.java
+++ b/src/main/java/com/azavea/gdal/GDALWarp.java
@@ -129,7 +129,7 @@ public class GDALWarp {
                                 NativeUtils.loadLibraryFromJar(GDALWARP_BINDINGS_RESOURCE_AMD64_ELF);
                         }
                         // ARM64
-                        else if (arch.contains("arm64"))
+                        else if (arch.contains("aarch64"))
                         {
                                 NativeUtils.loadLibraryFromJar(GDALWARP_BINDINGS_RESOURCE_ARM64_ELF);
                         }

--- a/src/tokens.cpp
+++ b/src/tokens.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Azavea
+ * Copyright 2019-2021 Azavea
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/tokens.hpp
+++ b/src/tokens.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Azavea
+ * Copyright 2019-2021 Azavea
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/types.hpp
+++ b/src/types.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Azavea
+ * Copyright 2019-2021 Azavea
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/unit_tests/Makefile
+++ b/src/unit_tests/Makefile
@@ -1,15 +1,17 @@
 CFLAGS ?= -Wall -Werror -O0 -ggdb3
-CFLAGS += -I..
+CFLAGS += -Wno-sign-compare -I..
 CXXFLAGS ?= -std=c++14
-LDFLAGS += $(shell pkg-config gdal --libs) -L.. -lgdalwarp_bindings -lpthread
+LDFLAGS += $(shell pkg-config gdal --libs) -L.. -lgdalwarp_bindings-$(ARCH) -lpthread
 GDALCFLAGS ?= $(shell pkg-config gdal --cflags)
 BOOST_ROOT ?= /usr/include
 SO ?= so
+ARCH ?= amd64
+
 
 .PHONY: tests clean cleaner cleanest
 .SILENT: tests
 
-tests: ../libgdalwarp_bindings.$(SO) ../experiments/data/c41078a1.tif token_tests dataset_tests cache_tests bindings_tests
+tests: ../libgdalwarp_bindings-$(ARCH).$(SO) ../experiments/data/c41078a1.tif token_tests dataset_tests cache_tests bindings_tests
 	LD_LIBRARY_PATH=$(LD_LIBRARY_PATH):.. ./token_tests
 	LD_LIBRARY_PATH=$(LD_LIBRARY_PATH):.. ./dataset_tests
 	LD_LIBRARY_PATH=$(LD_LIBRARY_PATH):.. ./cache_tests
@@ -18,19 +20,19 @@ tests: ../libgdalwarp_bindings.$(SO) ../experiments/data/c41078a1.tif token_test
 ../experiments/data/c41078a1.tif:
 	$(MAKE) -C ../experiments data/c41078a1.tif
 
-../libgdalwarp_bindings.$(SO):
+../libgdalwarp_bindings-$(ARCH).$(SO):
 	$(MAKE) -C .. libgdalwarp_bindings.$(SO)
 
-token_tests: token_tests.cpp ../libgdalwarp_bindings.$(SO)
+token_tests: token_tests.cpp ../libgdalwarp_bindings-$(ARCH).$(SO)
 	$(CXX) $(CFLAGS) $(CXXFLAGS) -I$(BOOST_ROOT) $< $(LDFLAGS) -lm -o $@
 
-dataset_tests: dataset_tests.cpp ../libgdalwarp_bindings.$(SO)
+dataset_tests: dataset_tests.cpp ../libgdalwarp_bindings-$(ARCH).$(SO)
 	$(CXX) $(CFLAGS) $(GDALCFLAGS) $(CXXFLAGS) -I$(BOOST_ROOT) $< $(LDFLAGS) -lm -o $@
 
-cache_tests: cache_tests.cpp ../libgdalwarp_bindings.$(SO)
+cache_tests: cache_tests.cpp ../libgdalwarp_bindings-$(ARCH).$(SO)
 	$(CXX) $(CFLAGS) $(GDALCFLAGS) $(CXXFLAGS) -I$(BOOST_ROOT) $< $(LDFLAGS) -lm -o $@
 
-bindings_tests: bindings_tests.cpp ../libgdalwarp_bindings.$(SO)
+bindings_tests: bindings_tests.cpp ../libgdalwarp_bindings-$(ARCH).$(SO)
 	$(CXX) $(CFLAGS) $(GDALCFLAGS) $(CXXFLAGS) -I$(BOOST_ROOT) $< $(LDFLAGS) -lm -o $@
 
 clean:

--- a/src/unit_tests/bindings_tests.cpp
+++ b/src/unit_tests/bindings_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Azavea
+ * Copyright 2019-2021 Azavea
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/unit_tests/cache_tests.cpp
+++ b/src/unit_tests/cache_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Azavea
+ * Copyright 2019-2021 Azavea
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/unit_tests/dataset_tests.cpp
+++ b/src/unit_tests/dataset_tests.cpp
@@ -90,7 +90,7 @@ BOOST_AUTO_TEST_CASE(get_offset)
     //
     // The root of the change:
     // Even though Offset and Scale values were not set, there was a logic that fixed it and set values to 1.0 and 0.0 in GDAL 2.x and GDAL 3.0.x.
-    // The change in the references changes the success flag behavior, so on the Python side 
+    // The change in the references changes the success flag behavior, so on the Python side
     // it is possible to interpret the return results as None.
     //
     // It is easy to check it with the following python code:
@@ -100,10 +100,10 @@ BOOST_AUTO_TEST_CASE(get_offset)
     // band = ds.GetRasterBand(1)
     // s = band.GetScale() # prints 1.0 in GDAL 2.x and 3.0.x, and None in GDAL 3.1.x
     // o = band.GetOffset() # prints 0.0 in GDAL 2.x and 3.0.x, and None in GDAL 3.1.x
-    // 
+    //
     // However, the Warp operation peformed in this test sets Scale and Offset values explicitly.
     // It explains why the old test case with the Warped dataset didn't change its behavior.
-    // 
+    //
     // It is easy to check it with the following python code:
     // w = gdal.Warp('', path, format='MEM', warpOptions=["-r", "bilinear", "-t_srs", "epsg:3857", "-co", "BLOCKXSIZE=512", "-co", "BLOCKYSIZE=512"])
     // wband = w.GetRasterBand(1)
@@ -114,7 +114,7 @@ BOOST_AUTO_TEST_CASE(get_offset)
     // - https://github.com/geotrellis/gdal-warp-bindings/pull/96 (PR that introduced this comment)
     // - https://github.com/OSGeo/gdal/issues/2579
     // - https://github.com/OSGeo/gdal/commit/69f25f253d141faf836c400676f9f94dd3f43707
-    // 
+    //
     // BOOST_TEST(success != false);
 #if !defined(PRE_GDAL_31)
     BOOST_TEST(success == false);
@@ -141,12 +141,12 @@ BOOST_AUTO_TEST_CASE(get_scale)
     // In GDAL 3.1 there happened a behavior change
     // Both GetScale and GetOffset functions are affected.
     // In the test raster Scale and Offset are not set and in GDAL 2.x and 3.0.x this case is handled differently.
-    // 
+    //
     // The root of the change:
     // Even though Offset and Scale values were not set, there was a logic that fixed it and set values to 1.0 and 0.0 in GDAL 2.x and GDAL 3.0.x.
-    // The change in the references changes the success flag behavior, so on the Python side 
+    // The change in the references changes the success flag behavior, so on the Python side
     // it is possible to interpret the return results as None.
-    // 
+    //
     // It is easy to check it with the following python code:
     // import gdal
     // path = /tmp/c41078a1.tif
@@ -154,10 +154,10 @@ BOOST_AUTO_TEST_CASE(get_scale)
     // band = ds.GetRasterBand(1)
     // s = band.GetScale() // prints 1.0 in GDAL 2.x and 3.0.x and None in GDAL 3.1.x
     // o = band.GetOffset() // prints 0.0 in GDAL 2.x and 3.0.x and None in GDAL 3.1.x
-    // 
+    //
     // However, the Warp operation peformed in this test sets Scale and Offset values explicitly.
     // It explains why the old test case with the Warped dataset didn't change its behavior.
-    // 
+    //
     // It is easy to check it with the following python code:
     // w = gdal.Warp('', path, format='MEM', warpOptions=["-r", "bilinear", "-t_srs", "epsg:3857", "-co", "BLOCKXSIZE=512", "-co", "BLOCKYSIZE=512"])
     // wband = w.GetRasterBand(1)
@@ -168,7 +168,7 @@ BOOST_AUTO_TEST_CASE(get_scale)
     // - https://github.com/geotrellis/gdal-warp-bindings/pull/96 (PR that introduced this comment)
     // - https://github.com/OSGeo/gdal/issues/2579
     // - https://github.com/OSGeo/gdal/commit/69f25f253d141faf836c400676f9f94dd3f43707
-    // 
+    //
     // BOOST_TEST(success != false);
 #if !defined(PRE_GDAL_31)
     BOOST_TEST(success == false);

--- a/src/unit_tests/dataset_tests.cpp
+++ b/src/unit_tests/dataset_tests.cpp
@@ -116,7 +116,9 @@ BOOST_AUTO_TEST_CASE(get_offset)
     // - https://github.com/OSGeo/gdal/commit/69f25f253d141faf836c400676f9f94dd3f43707
     // 
     // BOOST_TEST(success != false);
+#if !defined(PRE_GDAL_31)
     BOOST_TEST(success == false);
+#endif
     success = false;
 
     ld.get_offset(locked_dataset::WARPED, 1, &offset, &success);
@@ -168,7 +170,9 @@ BOOST_AUTO_TEST_CASE(get_scale)
     // - https://github.com/OSGeo/gdal/commit/69f25f253d141faf836c400676f9f94dd3f43707
     // 
     // BOOST_TEST(success != false);
+#if !defined(PRE_GDAL_31)
     BOOST_TEST(success == false);
+#endif
     success = false;
 
     ld.get_scale(locked_dataset::WARPED, 1, &scale, &success);

--- a/src/unit_tests/dataset_tests.cpp
+++ b/src/unit_tests/dataset_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Azavea
+ * Copyright 2019-2021 Azavea
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/unit_tests/token_tests.cpp
+++ b/src/unit_tests/token_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Azavea
+ * Copyright 2019-2021 Azavea
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
The `aarch64-linux-gnu` library is linked against GDAL 2.4 because that was was easily available in the Debian Buster package repository.  The build generated here has not been tested, though a separate build on an ARM64 EC2 instance did pass all tests.
   - [x] Test on Macintosh
   - [x] Test on `x86_64-linux-gnu`
   - [x] Test on `aarch64-linux-gnu`
   - [x] Update `README.md`, &c.


Closes https://github.com/geotrellis/gdal-warp-bindings/issues/106