### PR TITLE
Fix mvn gpg signing failed: Inappropriate ioctl for device

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -132,16 +132,16 @@ jobs:
       - run:
           name: Build a jar file, pack binaries into it and deploy it to maven central
           command: |
-            apt-get install maven -y &&
-            rm -f src/main/resources/resources/.gitkeep &&
-            cp -f /tmp/workdir/*.so /tmp/workdir/*.dylib /tmp/workdir/*.dll src/main/resources/resources/ &&
-            mvn package &&
-            if [ ! -z "${GPG_KEY}" ]; then
-              mkdir -p ~/.m2 &&
-              cp /workdir/.circleci/settings.xml ~/.m2/ &&
-              gpg --keyserver keyserver.ubuntu.com --recv-keys "0x${GPG_KEY_ID}" &&
-              echo "${GPG_KEY}" | base64 -d > signing_key.asc &&
-              gpg --batch --passphrase "${GPG_PASSPHRASE}" --import signing_key.asc &&
+            apt-get install maven -y && \
+            rm -f src/main/resources/resources/.gitkeep && \
+            cp -f /tmp/workdir/*.so /tmp/workdir/*.dylib /tmp/workdir/*.dll src/main/resources/resources/ && \
+            mvn package && \
+            if [ ! -z "${GPG_KEY}" ]; then \
+              mkdir -p ~/.m2 && \
+              cp /workdir/.circleci/settings.xml ~/.m2/ && \
+              gpg --keyserver keyserver.ubuntu.com --recv-keys "0x${GPG_KEY_ID}" && \
+              echo "${GPG_KEY}" | base64 -d > signing_key.asc && \
+              gpg --batch --passphrase "${GPG_PASSPHRASE}" --import signing_key.asc && \
               mvn deploy
             fi
 

--- a/.circleci/settings.xml
+++ b/.circleci/settings.xml
@@ -21,6 +21,15 @@
   </servers>
   <mirrors/>
   <proxies/>
-  <profiles/>
-  <activeProfiles/>
+  <profiles>
+    <profile>
+      <id>gpg</id>
+      <properties>
+        <gpg.passphrase>${env.GPG_PASSPHRASE}</gpg.passphrase>
+      </properties>
+    </profile>
+  </profiles>
+  <activeProfiles>
+    <activeProfile>gpg</activeProfile>
+  </activeProfiles>
 </settings>

--- a/pom.xml
+++ b/pom.xml
@@ -114,6 +114,13 @@
             <goals>
               <goal>sign</goal>
             </goals>
+            <configuration>
+              <gpgArguments>
+                <arg>--batch</arg>
+                <arg>--pinentry-mode</arg>
+                <arg>loopback</arg>
+              </gpgArguments> 
+            </configuration>
           </execution>
         </executions>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -117,8 +117,6 @@
             <configuration>
               <gpgArguments>
                 <arg>--batch</arg>
-                <arg>--pinentry-mode</arg>
-                <arg>loopback</arg>
               </gpgArguments> 
             </configuration>
           </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.6.0</version>
+        <version>3.10.1</version>
         <configuration>
           <source>1.8</source>
           <target>1.8</target>
@@ -57,7 +57,7 @@
       </plugin>
       <plugin>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>3.1.1</version>
+        <version>3.4.0</version>
         <configuration>
           <excludePackageNames>cz.adamh.utils</excludePackageNames>
         </configuration>
@@ -77,7 +77,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
-        <version>3.2.0</version>
+        <version>3.2.1</version>
         <executions>
           <execution>
             <id>attach-sources</id>
@@ -94,7 +94,7 @@
       <plugin>
         <groupId>org.sonatype.plugins</groupId>
         <artifactId>nexus-staging-maven-plugin</artifactId>
-        <version>1.6.8</version>
+        <version>1.6.13</version>
         <extensions>true</extensions>
         <configuration>
           <serverId>sonatype_releases</serverId>
@@ -106,7 +106,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-gpg-plugin</artifactId>
-        <version>1.6</version>
+        <version>3.0.1</version>
         <executions>
           <execution>
             <id>sign-artifacts</id>
@@ -119,7 +119,7 @@
       </plugin>
       <plugin>
         <artifactId>maven-deploy-plugin</artifactId>
-        <version>2.8.2</version>
+        <version>3.0.0</version>
         <configuration>
           <updateReleaseInfo>true</updateReleaseInfo>
         </configuration>


### PR DESCRIPTION
@jamesmcclain the real fix was to have a correct GPG key (I put the one that is used for the geotrellis-server), I also upgraded deps there. 

Let me know if you're going to replace it / replace with a GPG key with a passphrase. It may require some configuration adjustments (maven may work in the interactive mode, so we'd need to pass the passphrase into gpg through maven directly in case it's needed).

The things that helped me to understand the error were all plugings upgrade (most important - they have better error outputs) and `mvn -X` flag.

Note: 

`GPG_KEY = gpg --armor --export-secret-keys $LONG_ID | base64`

UPD: the new GPG key has a passphrase, we need to tell maven how to pass it to the agent.