### PR TITLE
Modify Circle CI pipeline to configure GDAL versions on manual trigger

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,14 @@
 version: 2.1
 
+parameters:
+  gdal-version:
+    type: string
+    default: "3.7.2"
+
 executors:
   gdal-build-executor-amd64:
     docker:
-      - image: daunnc/gdal-warp-bindings-environment:3.7.2-amd64
+      - image: daunnc/gdal-warp-bindings-environment:<< pipeline.parameters.gdal-version >>-amd64
     working_directory: /workdir
 
   gdal-build-executor-arm64:
@@ -71,10 +76,10 @@ jobs:
       CXX: c++
       CFLAGS: "-Wall -Werror -Og -ggdb3"
       JAVA_HOME: "/macintosh/jdk8u202-b08/Contents/Home"
-      GDALCFLAGS: "-I/macintosh/gdal/3.7.2/include"
+      GDALCFLAGS: "-I/macintosh/gdal/<< pipeline.parameters.gdal-version >>/include"
       CXXFLAGS: "-I/usr/osxcross/SDK/MacOSX10.10.sdk/usr/include/c++/v1"
       BOOST_ROOT: "/usr/local/include/boost_1_69_0"
-      LDFLAGS: "-mmacosx-version-min=10.9 -L/macintosh/gdal/3.7.2/lib -lgdal -lstdc++ -lpthread -Wl,-rpath,/usr/local/lib"
+      LDFLAGS: "-mmacosx-version-min=10.9 -L/macintosh/gdal/<< pipeline.parameters.gdal-version >>/lib -lgdal -lstdc++ -lpthread -Wl,-rpath,/usr/local/lib"
       LD_LIBRARY_PATH_ORIGIN: ""
       CROSS_ROOT: /usr/x86_64-apple-darwin14
       PATH: /usr/x86_64-apple-darwin14/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,10 @@ parameters:
   gdal-version:
     type: string
     default: "3.7.2"
+  skip-tests:
+    type: boolean
+    default: false
+    description: Skip tests, false by default.
 
 executors:
   gdal-build-executor-amd64:
@@ -25,6 +29,7 @@ jobs:
       CFLAGS: "-Wall -Werror -Og -ggdb3 -DSO_FINI -D_GNU_SOURCE"
       BOOST_ROOT: "/usr/local/include/boost_1_69_0"
       JAVA_HOME: "/usr/lib/jvm/java-8-openjdk-amd64"
+      SKIP_TESTS: << pipeline.parameters.skip-tests >>
     steps:
       - attach_workspace:
           at: /tmp/workdir/
@@ -32,9 +37,13 @@ jobs:
       - run:
           name: Build AMD64 Linux binaries and run unit tests
           command: |
-            ln -s /tmp/c41078a1.tif src/experiments/data/c41078a1.tif
-            make -j4 -C src tests
-            make -j4 -C src/experiments/thread pattern oversubscribe
+            if [ "$SKIP_TESTS" = true ]; then
+              make -j4 -C src libgdalwarp_bindings-amd64.so
+            else 
+              ln -s /tmp/c41078a1.tif src/experiments/data/c41078a1.tif
+              make -j4 -C src tests
+              make -j4 -C src/experiments/thread pattern oversubscribe
+            fi
       - persist_to_workspace:
           root: src
           paths:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [v1.2.0] - 2022-08-02
 
 ### Changed
-
 - Add support for `aarch64-linux-gnu` ARM64 on Linux [#107](https://github.com/geotrellis/gdal-warp-bindings/pull/107).
 - Add release instructions for developers to HOWTORELEASE.md
 

--- a/Docker/Makefile
+++ b/Docker/Makefile
@@ -1,0 +1,17 @@
+DOCKER_REGISTRY ?= quay.io/geotrellis
+
+gdal-3-6-4:
+	docker build \
+		--build-arg GDAL_VERSION=3.6.4 \
+		--build-arg GDAL_MACOS=libgdal-3.6.4-hbff29b3_22.conda \
+		--build-arg GDAL_WINDOWS=release-1916-x64-gdal-3-6-4-mapserver-8-0-1-libs.zip \
+		-f Dockerfile.environment-amd64 \
+		-t $(DOCKER_REGISTRY)/gdal-warp-bindings-environment:3.6.4-amd64 .
+
+gdal-3-7-2:
+	docker build \
+		--build-arg GDAL_VERSION=3.7.2 \
+		--build-arg GDAL_MACOS=libgdal-3.7.2-h85f6614_6.conda \
+		--build-arg GDAL_WINDOWS=release-1916-x64-gdal-3-7-2-mapserver-8-0-1-libs.zip \
+		-f Dockerfile.environment-amd64 \
+		-t $(DOCKER_REGISTRY)/gdal-warp-bindings-environment:3.7.2-amd64 .


### PR DESCRIPTION
This PR adds a makefile with commands to build GDAL images and adds CircleCI workflow parameters configuration so on a manual job trigger we can sepcify the image tag to build bindings version that matches a specific GDAL version;

Not really a solution to backfill all previous GDAL version, but with it we can try to publish a release manually for the previous one.

To read more about workflow params: https://circleci.com/docs/pipeline-variables/#pipeline-parameters-in-configuration

Example of a manually triggered pipeline: https://app.circleci.com/pipelines/github/pomadchin/gdal-warp-bindings/39/workflows/5d3955cf-e4a0-4a53-a814-772e3c2d9d96/jobs/167

I added two optional params into the pipeline to configure gdal version (docker image should be published already) and an option to skip tests.

<img width="1446" alt="image" src="https://github.com/geotrellis/gdal-warp-bindings/assets/4929546/b3f6e942-5804-40ca-bcd8-60aaf8c24302">
