### PR TITLE
Versioning Scheme README upd

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@ APIs are provided for C and Java.
 
 # Installation #
 
-Starting **gdal-warp-bindings version** `3.7` we changed the versioning scheme. Given the `{major}.{minor}.{patch}` version:
-* `{major}.{minor}` - matches the **GDAL library** version it is published for
-  * i.e. for GDAL `3.7.x` major = `3`, minor = `7`
-* `{patch}` - a **gdal-warp-bindings** update within the corresponding **GDAL library** `{major}.{minor}` version
-  * There can be multiple **gdal-warp-bindings** releases for the same **GDAL library** version. All releases are compatible with the matching **GDAL library** `{major}.{minor}` version
+Beginning with **gdal-warp-bindings version** `3.7` we've adopted a new versioning scheme intended to simplify versioning. Given a `{major}.{minor}.{patch}` version:
+* `{major}.{minor}` - matches the **GDAL** version it is published for
+  * e.g. gdal-warp-bindings of version `3.7.x` are suitable for GDAL versions `3.7.x` major = `3`, minor = `7`
+* `{patch}` - this portion of the version corresponds to updates within **gdal-warp-bindings** and should remain compatible with **GDAL library** `{major}.{minor}` versions
+  * This implies that there may be multiple **gdal-warp-bindings** releases for the same **GDAL library** version. All releases are compatible with the matching **GDAL library** `{major}.{minor}` version. Thus, higher patch versions are to be preferred.
 
 These bindings require a GDAL installation on your machine with the appropriate matching version:
 

--- a/README.md
+++ b/README.md
@@ -9,21 +9,18 @@ APIs are provided for C and Java.
 
 # Installation #
 
-Starting GDAL 3.7 we changed the versioning scheme, given the `{major}.{minor}.{patch}` version:
-* `{major}.{minor}` - matches the GDAL version it is published against
-  * for GDAL `3.7.1` major = `3`, minor = `7`
-* `{patch}` - is a lib update within the corresponding GDAL version
-  * There can be multiple releases for the same GDAL `{major}.{minor}.{patch}` version
-    * Bindings improvements but the compatible GDAL version is the same
-  * There can be releases that bump the GDAL patch version   
-    * Convenient releases to align with the GDAL patch version
+Starting **gdal-warp-bindings version** `3.7` we changed the versioning scheme. Given the `{major}.{minor}.{patch}` version:
+* `{major}.{minor}` - matches the **GDAL library** version it is published for
+  * i.e. for GDAL `3.7.x` major = `3`, minor = `7`
+* `{patch}` - a **gdal-warp-bindings** update within the corresponding **GDAL library** `{major}.{minor}` version
+  * There can be multiple **gdal-warp-bindings** releases for the same **GDAL library** version. All releases are compatible with the matching **GDAL library** `{major}.{minor}` version
 
 These bindings require a GDAL installation on your machine with the appropriate matching version:
 
 | GDAL Warp Bindings | OS                    |  GDAL | Shared Library {so,dylib,dll} |
 |--------------------|-----------------------|-------|-------------------------------|
-|              3.7.0 | Linux, MacOS, Windows | 3.7.2 | libgdal.so.33.3.7.2           |
-|              3.6.4 | Linux, MacOS, Windows | 3.6.4 | libgdal.so.33.3.6.4           |
+|              3.7.0 | Linux, MacOS, Windows | 3.7.x | libgdal.so.33.3.7.2           |
+|              3.6.4 | Linux, MacOS, Windows | 3.6.x | libgdal.so.33.3.6.4           |
 |              1.1.x | Linux (AMD64)         | 3.1.2 | libgdal.so.27                 |
 |              1.1.x | Linux (ARM64)         | 2.4.0 | libgdal.so.20                 |
 |              1.1.x | MacOS (AMD64)         | 3.1.2 | libgdal.27.dylib              |

--- a/README.md
+++ b/README.md
@@ -9,6 +9,15 @@ APIs are provided for C and Java.
 
 # Installation #
 
+Starting GDAL 3.7 we changed the versioning scheme, given the `{major}.{minor}.{patch}` version:
+* `{major}.{minor}` - matches the GDAL version it is published against
+  * for GDAL `3.7.1` major = `3`, minor = `7`
+* `{patch}` - is a lib update within the corresponding GDAL version
+  * There can be multiple releases for the same GDAL `{major}.{minor}.{patch}` version
+    * Bindings improvements but the compatible GDAL version is the same
+  * There can be releases that bump the GDAL patch version   
+    * Convenient releases to align with the GDAL patch version
+
 These bindings require a GDAL installation on your machine with the appropriate matching version:
 
 | GDAL Warp Bindings | OS                    |  GDAL | Shared Library {so,dylib,dll} |

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ APIs are provided for C and Java.
 
 # Installation #
 
-Beginning with **gdal-warp-bindings version** `3.7` we've adopted a new versioning scheme intended to simplify versioning. Given a `{major}.{minor}.{patch}` version:
+Beginning with **gdal-warp-bindings version** `3.7` we've adopted a new versioning scheme intended to simplify linking to native dependencies. Given a `{major}.{minor}.{patch}` version:
 * `{major}.{minor}` - matches the **GDAL** version it is published for
   * e.g. gdal-warp-bindings of version `3.7.x` are suitable for GDAL versions `3.7.x` major = `3`, minor = `7`
 * `{patch}` - this portion of the version corresponds to updates within **gdal-warp-bindings** and should remain compatible with **GDAL library** `{major}.{minor}` versions


### PR DESCRIPTION
Yo team! We need to document it, so easy to forget 🤦 

Another thing I noticed while doing a release is that GDAL dynamic libs are unique per _patch_ version i.e. `libgdal.so.33.3.7.2`. 

We have two choices for now given that

* `{gdal.major}.{gdal.minor}.{bindings.patch}` - as discussed before, patch for the lib improvements
  * patch can be lib improvements + bindings bump mixed in
  * the only disadvantage is that we may endup releasing 3.8.4 for the GDAL 3.8.2, which can be not ideal 
* `{gdal.major}.{gdal.minor}.{gdal.patch}.{bindings.patch}`
  *  I don't like this, but can be more transparent 🤷 
  * disadvantage here is that it's a non conventional versioning scheme