### PR TITLE
Add GDT_Int8 constant

### DIFF
--- a/src/main/java/com/azavea/gdal/GDALWarp.java
+++ b/src/main/java/com/azavea/gdal/GDALWarp.java
@@ -28,6 +28,7 @@ public class GDALWarp {
 
         public static final int GDT_Unknown = 0;
         public static final int GDT_Byte = 1;
+        public static final int GDT_Int8 = 14;
         public static final int GDT_UInt16 = 2;
         public static final int GDT_Int16 = 3;
         public static final int GDT_UInt32 = 4;


### PR DESCRIPTION
Fix https://github.com/geotrellis/gdal-warp-bindings/issues/129

The new DataType appeared in GDAL 3.7.0