### PR TITLE
GDAL 3.9.x Windows build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 parameters:
   gdal-version:
     type: string
-    default: "3.9.0"
+    default: "3.9.2"
   skip-tests:
     type: boolean
     default: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- GDAL 3.9.x Windows build [#132](https://github.com/geotrellis/gdal-warp-bindings/pull/132)
 
 ## [v3.9.0] - 2024-05-18
 ### Changed

--- a/Docker/Dockerfile.environment-amd64
+++ b/Docker/Dockerfile.environment-amd64
@@ -1,12 +1,15 @@
-# docker build -f Dockerfile.environment-amd64 -t quay.io/geotrellis/gdal-warp-bindings-environment:${GDAL_VERSION}-amd64 .
-# docker buildx build -f Dockerfile.environment-amd64 --platform linux/amd64 --push -t daunnc/gdal-warp-bindings-environment:3.9.0-amd64 .
+# docker buildx create --name multi-platform-builder
+# docker buildx use multi-platform-builder
+# 
+# docker build -f Dockerfile.environment-amd64 -t daunnc/gdal-warp-bindings-environment:${GDAL_VERSION}-amd64 .
+# docker buildx build -f Dockerfile.environment-amd64 --platform linux/amd64 --push -t daunnc/gdal-warp-bindings-environment:${GDAL_VERSION}-amd64 .
 
 FROM quay.io/geotrellis/gdal-warp-bindings-crossbuild:amd64-2
 LABEL maintainer="Azavea <info@azavea.com>"
 
-ARG GDAL_VERSION=3.9.0
-ARG GDAL_MACOS=libgdal-3.9.0-h8fe29fd_2.conda
-ARG GDAL_WINDOWS=release-1916-x64-gdal-3-8-1-mapserver-8-0-1-libs.zip
+ARG GDAL_VERSION=3.9.2
+ARG GDAL_MACOS=libgdal-3.9.2-h694c41f_1.conda 
+ARG GDAL_WINDOWS=release-1928-x64-gdal-3-9-1-mapserver-8-0-1-libs.zip
 ARG PROJ_VERSION=9.3.0
 ARG LIBTIFF_VERSION=4.1.0
 ARG CURL_VERSION=7.71.1
@@ -65,7 +68,7 @@ RUN mkdir -p /windows && \
     rm -r OpenJDK8U-jdk_x64_windows_hotspot_8u202b08.zip && \
     mkdir -p /windows/gdal && \
     cd /windows/gdal && \
-    wget "http://download.gisinternals.com/sdk/downloads/${GDAL_WINDOWS}" && \
+    wget "https://download.gisinternals.com/sdk/downloads/${GDAL_WINDOWS}" && \
     unzip ${GDAL_WINDOWS} && \
     rm -f ${GDAL_WINDOWS}
 

--- a/Docker/Dockerfile.environment-amd64
+++ b/Docker/Dockerfile.environment-amd64
@@ -8,7 +8,7 @@ FROM quay.io/geotrellis/gdal-warp-bindings-crossbuild:amd64-2
 LABEL maintainer="Azavea <info@azavea.com>"
 
 ARG GDAL_VERSION=3.9.2
-ARG GDAL_MACOS=libgdal-3.9.2-h694c41f_1.conda 
+ARG GDAL_MACOS=libgdal-core-3.9.2-ha3d9af8_1.conda
 ARG GDAL_WINDOWS=release-1928-x64-gdal-3-9-1-mapserver-8-0-1-libs.zip
 ARG PROJ_VERSION=9.3.0
 ARG LIBTIFF_VERSION=4.1.0
@@ -54,7 +54,7 @@ RUN mkdir -p /macintosh && \
     wget "https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u202-b08/OpenJDK8U-jdk_x64_mac_hotspot_8u202b08.tar.gz" && \
     tar axvf OpenJDK8U-jdk_x64_mac_hotspot_8u202b08.tar.gz && \
     rm -f OpenJDK8U-jdk_x64_mac_hotspot_8u202b08.tar.gz && \
-    wget "https://anaconda.org/conda-forge/libgdal/${GDAL_VERSION}/download/osx-64/${GDAL_MACOS}" && \
+    wget "https://anaconda.org/conda-forge/libgdal-core/${GDAL_VERSION}/download/osx-64/${GDAL_MACOS}" && \
     mkdir -p gdal/${GDAL_VERSION} && \
     cph extract ${GDAL_MACOS} --dest gdal/${GDAL_VERSION} && \
     rm -f ${GDAL_MACOS} && \


### PR DESCRIPTION
This PR updates Docker images to use the most up to date GDAL. And Windows binaries finally move to GDAL 3.9!

Also Conda GDAL packages changed (see the MacOS update): https://quansight.com/post/introducing-lightweight-versions-of-gdal-and-pdal/ 